### PR TITLE
Specify strict reader attributes on a class through a DSL

### DIFF
--- a/lib/strict/attributes/initializable.rb
+++ b/lib/strict/attributes/initializable.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Strict
+  module Attributes
+    module Initializable
+      # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
+      def initialize(**attributes)
+        remaining_attributes = Set.new(attributes.keys)
+        invalid_attributes = nil
+        missing_attributes = nil
+
+        self.class.strict_attributes_recipe.attributes.each do |attribute|
+          if remaining_attributes.delete?(attribute.name)
+            value = attributes.fetch(attribute.name)
+          elsif attribute.optional?
+            value = attribute.default_generator.call
+          else
+            missing_attributes ||= []
+            missing_attributes << attribute.name
+            next
+          end
+
+          value = attribute.coerce(value, for_class: self.class)
+          if attribute.valid?(value)
+            instance_variable_set(attribute.instance_variable, value)
+          else
+            invalid_attributes ||= {}
+            invalid_attributes[attribute] = value
+          end
+        end
+
+        return if remaining_attributes.none? && invalid_attributes.nil? && missing_attributes.nil?
+
+        raise InitializationError.new(
+          initializable_class: self.class,
+          remaining_attributes:,
+          invalid_attributes:,
+          missing_attributes:
+        )
+      end
+      # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
+    end
+  end
+end

--- a/lib/strict/initialization_error.rb
+++ b/lib/strict/initialization_error.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module Strict
+  class InitializationError < Error
+    attr_reader :remaining_attributes, :invalid_attributes, :missing_attributes
+
+    def initialize(initializable_class:, remaining_attributes:, invalid_attributes:, missing_attributes:)
+      super(message_from(initializable_class:, remaining_attributes:, invalid_attributes:, missing_attributes:))
+
+      @remaining_attributes = remaining_attributes
+      @invalid_attributes = invalid_attributes
+      @missing_attributes = missing_attributes
+    end
+
+    private
+
+    def message_from(initializable_class:, remaining_attributes:, invalid_attributes:, missing_attributes:)
+      details = [
+        invalid_attributes_message_from(invalid_attributes),
+        missing_attributes_message_from(missing_attributes),
+        remaining_attributes_message_from(remaining_attributes)
+      ].compact.join("\n")
+
+      "Initialization of #{initializable_class} failed because:\n#{details}"
+    end
+
+    def invalid_attributes_message_from(invalid_attributes)
+      return nil unless invalid_attributes
+
+      details = invalid_attributes.map do |attribute, value|
+        "    - '#{attribute.name}': got #{value.inspect}, expected #{attribute.validator.inspect}"
+      end.join("\n")
+
+      "  Some attributes were invalid:\n#{details}"
+    end
+
+    def missing_attributes_message_from(missing_attributes)
+      return nil unless missing_attributes
+
+      details = missing_attributes.map do |attribute_name|
+        "    - '#{attribute_name}'"
+      end.join("\n")
+
+      "  Some attributes were missing:\n#{details}"
+    end
+
+    def remaining_attributes_message_from(remaining_attributes)
+      return nil if remaining_attributes.none?
+
+      details = remaining_attributes.map do |attribute_name|
+        "    - '#{attribute_name}'"
+      end.join("\n")
+
+      "  Some attributes were provided, but not defined:\n#{details}"
+    end
+  end
+end

--- a/lib/strict/reader/attributes.rb
+++ b/lib/strict/reader/attributes.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Strict
+  module Reader
+    module Attributes
+      def attributes(&block)
+        block ||= -> {}
+        recipe = Strict::Attributes::Dsl.run(&block)
+        include Module.new(recipe)
+        include Strict::Attributes::Initializable
+        extend ClassMethods
+      end
+    end
+  end
+end

--- a/lib/strict/reader/class_methods.rb
+++ b/lib/strict/reader/class_methods.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Strict
+  module Reader
+    module ClassMethods
+      def strict_attributes_recipe
+        self::STRICT_INTERNAL_ATTRIBUTES_RECIPE__
+      end
+    end
+  end
+end

--- a/lib/strict/reader/module.rb
+++ b/lib/strict/reader/module.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Strict
+  module Reader
+    class Module < ::Module
+      def initialize(recipe)
+        super()
+
+        const_set(:STRICT_INTERNAL_ATTRIBUTES_RECIPE__, recipe)
+        recipe.attributes.each do |attribute|
+          module_eval(
+            "def #{attribute.name} = #{attribute.instance_variable}", # def name = @instance_variable
+            __FILE__,
+            __LINE__ - 2
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/strict/validators/all_of.rb
+++ b/lib/strict/validators/all_of.rb
@@ -14,6 +14,11 @@ module Strict
           subvalidator === value
         end
       end
+
+      def inspect
+        "AllOf(#{subvalidators.map(&:inspect).join(', ')})"
+      end
+      alias to_s inspect
     end
   end
 end

--- a/lib/strict/validators/any_of.rb
+++ b/lib/strict/validators/any_of.rb
@@ -14,6 +14,11 @@ module Strict
           subvalidator === value
         end
       end
+
+      def inspect
+        "AnyOf(#{subvalidators.map(&:inspect).join(', ')})"
+      end
+      alias to_s inspect
     end
   end
 end

--- a/lib/strict/validators/anything.rb
+++ b/lib/strict/validators/anything.rb
@@ -10,6 +10,11 @@ module Strict
       def ===(_value)
         true
       end
+
+      def inspect
+        "Anything()"
+      end
+      alias to_s inspect
     end
   end
 end

--- a/lib/strict/validators/array_of.rb
+++ b/lib/strict/validators/array_of.rb
@@ -14,6 +14,11 @@ module Strict
           element_validator === v
         end
       end
+
+      def inspect
+        "ArrayOf(#{element_validator.inspect})"
+      end
+      alias to_s inspect
     end
   end
 end

--- a/lib/strict/validators/boolean.rb
+++ b/lib/strict/validators/boolean.rb
@@ -10,6 +10,11 @@ module Strict
       def ===(value)
         value.equal?(true) || value.equal?(false)
       end
+
+      def inspect
+        "Boolean()"
+      end
+      alias to_s inspect
     end
   end
 end

--- a/lib/strict/validators/hash_of.rb
+++ b/lib/strict/validators/hash_of.rb
@@ -15,6 +15,11 @@ module Strict
           key_validator === k && value_validator === v
         end
       end
+
+      def inspect
+        "HashOf(#{key_validator.inspect} => #{value_validator.inspect})"
+      end
+      alias to_s inspect
     end
   end
 end

--- a/lib/strict/validators/range_of.rb
+++ b/lib/strict/validators/range_of.rb
@@ -14,6 +14,11 @@ module Strict
           element_validator === v
         end
       end
+
+      def inspect
+        "RangeOf(#{element_validator.inspect})"
+      end
+      alias to_s inspect
     end
   end
 end

--- a/test/strict/initialization_error_test.rb
+++ b/test/strict/initialization_error_test.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe Strict::InitializationError do
+  describe ".new" do
+    before do
+      @initializable_class = Class.new
+    end
+
+    it "builds a message with only invalid attributes" do
+      error = Strict::InitializationError.new(
+        initializable_class: @initializable_class,
+        remaining_attributes: [],
+        invalid_attributes: {
+          Strict::Attribute.make(:attr_one, Strict::Validators::AnyOf.new(1, "2", nil)) => 2,
+          Strict::Attribute.make(:attr_two, nil) => 2
+        },
+        missing_attributes: nil
+      )
+
+      expected_message = <<~MESSAGE.chomp
+        Initialization of #{@initializable_class} failed because:
+          Some attributes were invalid:
+            - 'attr_one': got 2, expected AnyOf(1, "2", nil)
+            - 'attr_two': got 2, expected nil
+      MESSAGE
+
+      assert_equal expected_message, error.message
+    end
+
+    it "builds a message with only missing attributes" do
+      error = Strict::InitializationError.new(
+        initializable_class: @initializable_class,
+        remaining_attributes: [],
+        invalid_attributes: nil,
+        missing_attributes: %i[attr_three attr_four]
+      )
+
+      expected_message = <<~MESSAGE.chomp
+        Initialization of #{@initializable_class} failed because:
+          Some attributes were missing:
+            - 'attr_three'
+            - 'attr_four'
+      MESSAGE
+
+      assert_equal expected_message, error.message
+    end
+
+    it "builds a message with only remaining attributes" do
+      error = Strict::InitializationError.new(
+        initializable_class: @initializable_class,
+        remaining_attributes: %i[attr_five attr_six],
+        invalid_attributes: nil,
+        missing_attributes: nil
+      )
+
+      expected_message = <<~MESSAGE.chomp
+        Initialization of #{@initializable_class} failed because:
+          Some attributes were provided, but not defined:
+            - 'attr_five'
+            - 'attr_six'
+      MESSAGE
+
+      assert_equal expected_message, error.message
+    end
+
+    it "builds a message with all kinds of attributes" do
+      error = Strict::InitializationError.new(
+        initializable_class: @initializable_class,
+        remaining_attributes: %i[attr_five attr_six],
+        invalid_attributes: {
+          Strict::Attribute.make(:attr_one, Strict::Validators::AnyOf.new(1, "2", nil)) => 2,
+          Strict::Attribute.make(:attr_two, nil) => 2
+        },
+        missing_attributes: %i[attr_three attr_four]
+      )
+
+      expected_message = <<~MESSAGE.chomp
+        Initialization of #{@initializable_class} failed because:
+          Some attributes were invalid:
+            - 'attr_one': got 2, expected AnyOf(1, "2", nil)
+            - 'attr_two': got 2, expected nil
+          Some attributes were missing:
+            - 'attr_three'
+            - 'attr_four'
+          Some attributes were provided, but not defined:
+            - 'attr_five'
+            - 'attr_six'
+      MESSAGE
+
+      assert_equal expected_message, error.message
+    end
+  end
+end

--- a/test/strict/reader/attributes_test.rb
+++ b/test/strict/reader/attributes_test.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe Strict::Reader::Attributes do
+  before do
+    @reader_class = Class.new do
+      extend Strict::Reader::Attributes
+
+      attributes do
+        foo Integer
+        bar String, coerce: :some_coercer
+        baz String, default: "some string"
+      end
+
+      def self.some_coercer(value)
+        value.to_s
+      end
+    end
+  end
+
+  it "exposes the recipe on the class" do
+    assert_equal Strict::Attributes::Recipe, @reader_class.strict_attributes_recipe.class
+    assert_equal %i[foo bar baz], @reader_class.strict_attributes_recipe.attributes.map(&:name)
+  end
+
+  it "does not expose writer methods" do
+    instance = @reader_class.new(foo: 1, bar: "2", baz: "3")
+
+    assert_raises(NoMethodError) do
+      instance.foo = 1
+    end
+  end
+
+  it "exposes reader methods" do
+    instance = @reader_class.new(foo: 1, bar: "2", baz: "3")
+    assert_equal 1, instance.foo
+  end
+
+  it "does not allow invalid arguments" do
+    error = assert_raises(Strict::InitializationError) do
+      @reader_class.new(foo: "1", bar: "2", baz: "3")
+    end
+
+    assert_match(/'foo'/, error.message)
+  end
+
+  it "coerces arguments that can be coerced" do
+    instance = @reader_class.new(foo: 1, bar: 2, baz: "3")
+    assert_equal "2", instance.bar
+  end
+
+  it "does not require optional attributes" do
+    instance = @reader_class.new(foo: 1, bar: "2")
+    assert_equal "some string", instance.baz
+  end
+
+  it "requires mandatory attributes" do
+    error = assert_raises(Strict::InitializationError) do
+      @reader_class.new(foo: 1, baz: "3")
+    end
+
+    assert_match(/'bar'/, error.message)
+  end
+
+  it "does not allow additional attributes" do
+    error = assert_raises(Strict::InitializationError) do
+      @reader_class.new(foo: 1, bar: "2", baz: "3", bat: "uh oh")
+    end
+
+    assert_match(/'bat'/, error.message)
+  end
+
+  it "aggregates errors" do
+    error = assert_raises(Strict::InitializationError) do
+      @reader_class.new(foo: "1", baz: "3", bat: "uh oh")
+    end
+
+    assert_match(/'foo'/, error.message)
+    assert_match(/'bar'/, error.message)
+    assert_match(/'bat'/, error.message)
+  end
+end

--- a/test/strict/validators/all_of_test.rb
+++ b/test/strict/validators/all_of_test.rb
@@ -33,4 +33,18 @@ describe Strict::Validators::AllOf do
       refute all_of === @value
     end
   end
+
+  describe "#to_s" do
+    it "is meaningful" do
+      all_of = Strict::Validators::AllOf.new(1, "2", nil, Integer)
+      assert_equal "AllOf(1, \"2\", nil, Integer)", all_of.to_s
+    end
+  end
+
+  describe "#inspect" do
+    it "is meaningful" do
+      all_of = Strict::Validators::AllOf.new(1, "2", nil, Integer)
+      assert_equal "AllOf(1, \"2\", nil, Integer)", all_of.inspect
+    end
+  end
 end

--- a/test/strict/validators/any_of_test.rb
+++ b/test/strict/validators/any_of_test.rb
@@ -33,4 +33,18 @@ describe Strict::Validators::AnyOf do
       refute any_of === @value
     end
   end
+
+  describe "#to_s" do
+    it "is meaningful" do
+      any_of = Strict::Validators::AnyOf.new(1, "2", nil, Integer)
+      assert_equal "AnyOf(1, \"2\", nil, Integer)", any_of.to_s
+    end
+  end
+
+  describe "#inspect" do
+    it "is meaningful" do
+      any_of = Strict::Validators::AnyOf.new(1, "2", nil, Integer)
+      assert_equal "AnyOf(1, \"2\", nil, Integer)", any_of.inspect
+    end
+  end
 end

--- a/test/strict/validators/anything_test.rb
+++ b/test/strict/validators/anything_test.rb
@@ -13,4 +13,18 @@ describe Strict::Validators::Anything do
       assert anything === Strict
     end
   end
+
+  describe "#to_s" do
+    it "is meaningful" do
+      anything = Strict::Validators::Anything.instance
+      assert_equal "Anything()", anything.to_s
+    end
+  end
+
+  describe "#inspect" do
+    it "is meaningful" do
+      anything = Strict::Validators::Anything.instance
+      assert_equal "Anything()", anything.inspect
+    end
+  end
 end

--- a/test/strict/validators/array_of_test.rb
+++ b/test/strict/validators/array_of_test.rb
@@ -24,4 +24,18 @@ describe Strict::Validators::ArrayOf do
       refute @array_of === (0..10)
     end
   end
+
+  describe "#to_s" do
+    it "is meaningful" do
+      array_of = Strict::Validators::ArrayOf.new("2")
+      assert_equal "ArrayOf(\"2\")", array_of.to_s
+    end
+  end
+
+  describe "#inspect" do
+    it "is meaningful" do
+      array_of = Strict::Validators::ArrayOf.new("2")
+      assert_equal "ArrayOf(\"2\")", array_of.inspect
+    end
+  end
 end

--- a/test/strict/validators/boolean_test.rb
+++ b/test/strict/validators/boolean_test.rb
@@ -21,4 +21,18 @@ describe Strict::Validators::Boolean do
       refute @boolean === "string"
     end
   end
+
+  describe "#to_s" do
+    it "is meaningful" do
+      boolean = Strict::Validators::Boolean.instance
+      assert_equal "Boolean()", boolean.to_s
+    end
+  end
+
+  describe "#inspect" do
+    it "is meaningful" do
+      boolean = Strict::Validators::Boolean.instance
+      assert_equal "Boolean()", boolean.inspect
+    end
+  end
 end

--- a/test/strict/validators/hash_of_test.rb
+++ b/test/strict/validators/hash_of_test.rb
@@ -29,4 +29,18 @@ describe Strict::Validators::HashOf do
       refute @hash_of === [[1, "one"]]
     end
   end
+
+  describe "#to_s" do
+    it "is meaningful" do
+      hash_of = Strict::Validators::HashOf.new("2", "3")
+      assert_equal "HashOf(\"2\" => \"3\")", hash_of.to_s
+    end
+  end
+
+  describe "#inspect" do
+    it "is meaningful" do
+      hash_of = Strict::Validators::HashOf.new("2", "3")
+      assert_equal "HashOf(\"2\" => \"3\")", hash_of.inspect
+    end
+  end
 end

--- a/test/strict/validators/range_of_test.rb
+++ b/test/strict/validators/range_of_test.rb
@@ -44,4 +44,18 @@ describe Strict::Validators::RangeOf do
       refute @range_of === [0, 1, 2, 3, 4]
     end
   end
+
+  describe "#to_s" do
+    it "is meaningful" do
+      range_of = Strict::Validators::RangeOf.new("2")
+      assert_equal "RangeOf(\"2\")", range_of.to_s
+    end
+  end
+
+  describe "#inspect" do
+    it "is meaningful" do
+      range_of = Strict::Validators::RangeOf.new("2")
+      assert_equal "RangeOf(\"2\")", range_of.inspect
+    end
+  end
 end


### PR DESCRIPTION
- Provide nicer output when printing validator instances
- Introduce a bulk initialization error for issues during initialization
- Specify strict reader attributes on a class through a DSL
