### PR TITLE
DSL for strict method signatures

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,13 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
+    debug (1.6.1)
+      irb (>= 1.3.6)
+      reline (>= 0.3.1)
     gem-release (2.2.2)
+    io-console (0.5.11)
+    irb (1.4.1)
+      reline (>= 0.3.0)
     json (2.6.2)
     minitest (5.16.2)
     minitest-spec-context (0.0.4)
@@ -18,6 +24,8 @@ GEM
     rainbow (3.1.1)
     rake (13.0.6)
     regexp_parser (2.6.0)
+    reline (0.3.1)
+      io-console (~> 0.5)
     rexml (3.2.5)
     rubocop (1.36.0)
       json (~> 2.3)
@@ -44,6 +52,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  debug (>= 1.0.0)
   gem-release (~> 2.2)
   minitest (~> 5.0)
   minitest-spec-context (~> 0.0.4)

--- a/lib/strict/attributes/configuration.rb
+++ b/lib/strict/attributes/configuration.rb
@@ -20,7 +20,7 @@ module Strict
         private
 
         def message_from(attribute_name:)
-          "Strict tried to find an attribute named #{attribute_name} but was unable." \
+          "Strict tried to find an attribute named #{attribute_name} but was unable. " \
             "It's likely this in an internal bug, feel free to open an issue at #{Strict::ISSUE_TRACKER} for help."
         end
       end

--- a/lib/strict/attributes/dsl.rb
+++ b/lib/strict/attributes/dsl.rb
@@ -11,6 +11,8 @@ module Strict
         end
       end
 
+      include ::Strict::Dsl::Validatable
+
       attr_reader :__strict_dsl_internal_attributes
 
       def initialize
@@ -35,28 +37,6 @@ module Strict
         first_letter = method_name.to_s.each_char.first
         first_letter.eql?(first_letter.downcase)
       end
-
-      ## Validators
-      # rubocop:disable Naming/MethodName
-
-      def AllOf(*subvalidators) = ::Strict::Validators::AllOf.new(*subvalidators)
-      def AnyOf(*subvalidators) = ::Strict::Validators::AnyOf.new(*subvalidators)
-      def Anything = ::Strict::Validators::Anything.instance
-      def ArrayOf(element_validator) = ::Strict::Validators::ArrayOf.new(element_validator)
-      def Boolean = ::Strict::Validators::Boolean.instance
-
-      def HashOf(key_validator_to_value_validator)
-        if key_validator_to_value_validator.size != 1
-          raise ArgumentError, "HashOf's usage is: HashOf(KeyValidator => ValueValidator)"
-        end
-
-        key_validator, value_validator = key_validator_to_value_validator.first
-        ::Strict::Validators::HashOf.new(key_validator, value_validator)
-      end
-
-      def RangeOf(element_validator) = ::Strict::Validators::RangeOf.new(element_validator)
-
-      # rubocop:enable Naming/MethodName
     end
   end
 end

--- a/lib/strict/dsl/validatable.rb
+++ b/lib/strict/dsl/validatable.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Strict
+  module Dsl
+    module Validatable
+      # rubocop:disable Naming/MethodName
+
+      def AllOf(*subvalidators) = ::Strict::Validators::AllOf.new(*subvalidators)
+      def AnyOf(*subvalidators) = ::Strict::Validators::AnyOf.new(*subvalidators)
+      def Anything = ::Strict::Validators::Anything.instance
+      def ArrayOf(element_validator) = ::Strict::Validators::ArrayOf.new(element_validator)
+      def Boolean = ::Strict::Validators::Boolean.instance
+
+      def HashOf(key_validator_to_value_validator)
+        if key_validator_to_value_validator.size != 1
+          raise ArgumentError, "HashOf's usage is: HashOf(KeyValidator => ValueValidator)"
+        end
+
+        key_validator, value_validator = key_validator_to_value_validator.first
+        ::Strict::Validators::HashOf.new(key_validator, value_validator)
+      end
+
+      def RangeOf(element_validator) = ::Strict::Validators::RangeOf.new(element_validator)
+
+      # rubocop:enable Naming/MethodName
+    end
+  end
+end

--- a/lib/strict/methods/configuration.rb
+++ b/lib/strict/methods/configuration.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Strict
+  module Methods
+    class Configuration
+      attr_reader :parameters, :returns
+
+      def initialize(parameters:, returns:)
+        @parameters = parameters
+        @returns = returns
+      end
+    end
+  end
+end

--- a/lib/strict/methods/dsl.rb
+++ b/lib/strict/methods/dsl.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module Strict
+  module Methods
+    class Dsl < BasicObject
+      class << self
+        def run(&)
+          dsl = new
+          dsl.instance_eval(&)
+          ::Strict::Methods::Configuration.new(
+            parameters: dsl.__strict_dsl_internal_parameters.values,
+            returns: dsl.__strict_dsl_internal_returns
+          )
+        end
+      end
+
+      include ::Strict::Dsl::Validatable
+
+      attr_reader :__strict_dsl_internal_parameters, :__strict_dsl_internal_returns
+
+      def initialize
+        @__strict_dsl_internal_parameters = {}
+        @__strict_dsl_internal_returns = ::Strict::Return.make
+      end
+
+      def returns(*args, **kwargs)
+        self.__strict_dsl_internal_returns = ::Strict::Return.make(*args, **kwargs)
+        nil
+      end
+
+      def strict_parameter(*args, **kwargs)
+        parameter = ::Strict::Parameter.make(*args, **kwargs)
+        __strict_dsl_internal_parameters[parameter.name] = parameter
+        nil
+      end
+
+      def method_missing(name, *args, **kwargs)
+        if respond_to_missing?(name)
+          strict_parameter(name, *args, **kwargs)
+        else
+          super
+        end
+      end
+
+      def respond_to_missing?(method_name, _include_private = nil)
+        first_letter = method_name.to_s.each_char.first
+        first_letter.eql?(first_letter.downcase)
+      end
+
+      private
+
+      attr_writer :__strict_dsl_internal_returns
+    end
+  end
+end

--- a/lib/strict/parameter.rb
+++ b/lib/strict/parameter.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+module Strict
+  class Parameter
+    NOT_PROVIDED = ::Object.new.freeze
+
+    class << self
+      def make(name, validator = Validators::Anything.instance, coerce: false, **defaults)
+        unless valid_defaults?(**defaults)
+          raise ArgumentError, "Only one of 'default', 'default_value', or 'default_generator' can be provided"
+        end
+
+        new(name: name.to_sym, validator:, default_generator: make_default_generator(**defaults), coercer: coerce)
+      end
+
+      private
+
+      def valid_defaults?(default: NOT_PROVIDED, default_value: NOT_PROVIDED, default_generator: NOT_PROVIDED)
+        defaults_provided = [default, default_value, default_generator].count do |default_option|
+          !default_option.equal?(NOT_PROVIDED)
+        end
+
+        defaults_provided <= 1
+      end
+
+      def make_default_generator(default: NOT_PROVIDED, default_value: NOT_PROVIDED, default_generator: NOT_PROVIDED)
+        if !default.equal?(NOT_PROVIDED)
+          default.respond_to?(:call) ? default : -> { default }
+        elsif !default_value.equal?(NOT_PROVIDED)
+          -> { default_value }
+        elsif !default_generator.equal?(NOT_PROVIDED)
+          default_generator
+        else
+          NOT_PROVIDED
+        end
+      end
+    end
+
+    attr_reader :name, :validator, :default_generator, :coercer
+
+    def initialize(name:, validator:, default_generator:, coercer:)
+      @name = name.to_sym
+      @validator = validator
+      @default_generator = default_generator
+      @coercer = coercer
+      @optional = !default_generator.equal?(NOT_PROVIDED)
+    end
+
+    def optional?
+      @optional
+    end
+
+    def valid?(value)
+      validator === value
+    end
+
+    def coerce(value)
+      return value unless coercer
+
+      coercer.call(value)
+    end
+  end
+end

--- a/lib/strict/return.rb
+++ b/lib/strict/return.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Strict
+  class Return
+    class << self
+      def make(validator = Validators::Anything.instance, coerce: false)
+        new(validator:, coercer: coerce)
+      end
+    end
+
+    attr_reader :validator, :coercer
+
+    def initialize(validator:, coercer:)
+      @validator = validator
+      @coercer = coercer
+    end
+
+    def valid?(value)
+      validator === value
+    end
+
+    def coerce(value)
+      return value unless coercer
+
+      coercer.call(value)
+    end
+  end
+end

--- a/strict.gemspec
+++ b/strict.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "zeitwerk", "~> 2.6"
+  spec.add_development_dependency "debug", ">= 1.0.0"
   spec.add_development_dependency "gem-release", "~> 2.2"
   spec.add_development_dependency "minitest", "~> 5.0"
   spec.add_development_dependency "minitest-spec-context", "~> 0.0.4"

--- a/test/strict/methods/dsl_test.rb
+++ b/test/strict/methods/dsl_test.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe Strict::Methods::Dsl do
+  describe ".run" do
+    it "creates a configuration with valid identifiers and arguments" do
+      configuration = Strict::Methods::Dsl.run do
+        no_arguments
+        _underscore_identifier
+        question?
+        unsafe!
+        default_with_value default: 1
+        default_with_callable default: -> { 1 }
+        default_value default_value: 1
+        default_generator default_generator: -> { 1 }
+        coerce coerce: ->(value) { "coerced #{value}" }
+        all_of AllOf(Enumerable, Comparable)
+        any_of AnyOf(Integer, String, nil)
+        anything Anything()
+        array_of ArrayOf(Anything())
+        boolean Boolean()
+        hash_of HashOf(Integer => String)
+        range_of RangeOf(Numeric)
+        returns Boolean()
+      end
+      parameters = configuration.parameters.to_h { |p| [p.name, p] }
+
+      assert_equal Strict::Validators::Anything.instance, parameters.fetch(:no_arguments).validator
+      refute_nil parameters.fetch(:_underscore_identifier)
+      refute_nil parameters.fetch(:question?)
+      refute_nil parameters.fetch(:unsafe!)
+      assert_equal 1, parameters.fetch(:default_with_value).default_generator.call
+      assert_equal 1, parameters.fetch(:default_with_callable).default_generator.call
+      assert_equal 1, parameters.fetch(:default_value).default_generator.call
+      assert_equal 1, parameters.fetch(:default_generator).default_generator.call
+      assert_equal "coerced value", parameters.fetch(:coerce).coerce("value")
+      assert_equal Strict::Validators::AllOf, parameters.fetch(:all_of).validator.class
+      assert_equal Strict::Validators::AnyOf, parameters.fetch(:any_of).validator.class
+      assert_equal Strict::Validators::Anything, parameters.fetch(:anything).validator.class
+      assert_equal Strict::Validators::ArrayOf, parameters.fetch(:array_of).validator.class
+      assert_equal Strict::Validators::Boolean, parameters.fetch(:boolean).validator.class
+      assert_equal Strict::Validators::HashOf, parameters.fetch(:hash_of).validator.class
+      assert_equal Strict::Validators::RangeOf, parameters.fetch(:range_of).validator.class
+      assert_equal Strict::Validators::Boolean, configuration.returns.validator.class
+    end
+
+    it "allows overwriting parameters" do
+      configuration = Strict::Methods::Dsl.run do
+        foo String
+        foo Integer
+      end
+
+      assert_equal %i[foo], configuration.parameters.map(&:name)
+      assert_equal [Integer], configuration.parameters.map(&:validator)
+    end
+
+    it "allows manually creating parameters" do
+      configuration = Strict::Methods::Dsl.run do
+        strict_parameter :if
+      end
+
+      assert_equal [:if], configuration.parameters.map(&:name)
+    end
+
+    it "allows conflicting returns parameters and declarations" do
+      configuration = Strict::Methods::Dsl.run do
+        strict_parameter :returns, Integer
+        returns Boolean()
+      end
+      parameters = configuration.parameters.to_h { |p| [p.name, p] }
+
+      assert_equal Integer, parameters.fetch(:returns).validator
+      assert_equal Strict::Validators::Boolean, configuration.returns.validator.class
+    end
+
+    it "defines returns as anything when not specified" do
+      configuration = Strict::Methods::Dsl.run do
+        foo String
+      end
+
+      assert_equal Strict::Validators::Anything, configuration.returns.validator.class
+    end
+  end
+end

--- a/test/strict/parameter_test.rb
+++ b/test/strict/parameter_test.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe Strict::Parameter do
+  describe ".make" do
+    it "has defaults when only given a name" do
+      parameter = Strict::Parameter.make("attr_name")
+
+      assert_equal :attr_name, parameter.name
+      assert_equal Strict::Validators::Anything.instance, parameter.validator
+      assert_equal Strict::Parameter::NOT_PROVIDED, parameter.default_generator
+      refute parameter.coercer
+      refute_predicate parameter, :optional?
+    end
+
+    it "accepts a combination of all arguments" do
+      parameter = Strict::Parameter.make(
+        :attr_name,
+        Strict::Validators::Boolean.instance,
+        coerce: ->(value) { value + 1 },
+        default: 1
+      )
+
+      assert_equal :attr_name, parameter.name
+      assert_equal Strict::Validators::Boolean.instance, parameter.validator
+      refute_equal Strict::Parameter::NOT_PROVIDED, parameter.default_generator
+      assert_equal 1, parameter.default_generator.call
+      assert parameter.coercer
+      assert_predicate parameter, :optional?
+    end
+
+    it "accepts a validator" do
+      parameter = Strict::Parameter.make(:attr_name, Strict::Validators::Boolean.instance)
+
+      assert_equal Strict::Validators::Boolean.instance, parameter.validator
+    end
+
+    it "accepts a coerce value" do
+      parameter = Strict::Parameter.make(:attr_name, coerce: ->(value) { value + 1 })
+
+      assert parameter.coercer
+    end
+
+    it "accepts a value for 'default'" do
+      parameter = Strict::Parameter.make(:attr_name, default: 1)
+
+      refute_equal Strict::Parameter::NOT_PROVIDED, parameter.default_generator
+      assert_equal 1, parameter.default_generator.call
+      assert_predicate parameter, :optional?
+    end
+
+    it "accepts a callable for 'default'" do
+      parameter = Strict::Parameter.make(:attr_name, default: -> { 1 })
+
+      refute_equal Strict::Parameter::NOT_PROVIDED, parameter.default_generator
+      assert_equal 1, parameter.default_generator.call
+      assert_predicate parameter, :optional?
+    end
+
+    it "accepts a value for 'default_value'" do
+      parameter = Strict::Parameter.make(:attr_name, default_value: -> { 1 })
+
+      refute_equal Strict::Parameter::NOT_PROVIDED, parameter.default_generator
+      assert_equal 1, parameter.default_generator.call.call
+      assert_predicate parameter, :optional?
+    end
+
+    it "accepts a callable for 'default_generator'" do
+      parameter = Strict::Parameter.make(:attr_name, default_generator: -> { 1 })
+
+      refute_equal Strict::Parameter::NOT_PROVIDED, parameter.default_generator
+      assert_equal 1, parameter.default_generator.call
+      assert_predicate parameter, :optional?
+    end
+
+    it "does not accept multiple defaults" do
+      assert_raises(ArgumentError) do
+        Strict::Parameter.make(:attr_name, default: 1, default_value: 1)
+      end
+    end
+  end
+
+  describe "#valid?" do
+    it "uses the validator to check if the value is valid" do
+      parameter = Strict::Parameter.make(:attr_name, Strict::Validators::Boolean.instance)
+
+      assert parameter.valid?(true)
+      assert parameter.valid?(false)
+      refute parameter.valid?(nil)
+      refute parameter.valid?(1)
+
+      parameter = Strict::Parameter.make(
+        :attr_name,
+        Strict::Validators::AnyOf.new(Strict::Validators::Boolean.instance, nil)
+      )
+
+      assert parameter.valid?(true)
+      assert parameter.valid?(false)
+      assert parameter.valid?(nil)
+      refute parameter.valid?(1)
+    end
+  end
+
+  describe "#coerce" do
+    it "returns the value if coercion is not enabled" do
+      parameter = Strict::Parameter.make(:attr_name, coerce: false)
+
+      assert_equal "value", parameter.coerce("value")
+    end
+
+    it "does not support .coerce_attr_name coercion" do
+      parameter = Strict::Parameter.make(:attr_name, coerce: true)
+
+      assert_raises(NoMethodError) do
+        parameter.coerce("value")
+      end
+    end
+
+    it "does not support coercion methods is passed" do
+      parameter = Strict::Parameter.make(:attr_name, coerce: :some_method)
+
+      assert_raises(NoMethodError) do
+        parameter.coerce("value")
+      end
+    end
+
+    it "calls the callable if one is passed" do
+      parameter = Strict::Parameter.make(:attr_name, coerce: ->(value) { "coerced #{value}" })
+
+      assert_equal "coerced value", parameter.coerce("value")
+    end
+  end
+end

--- a/test/strict/return_test.rb
+++ b/test/strict/return_test.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe Strict::Return do
+  describe ".make" do
+    it "has defaults for the validator and coercion" do
+      returns = Strict::Return.make
+
+      assert_equal Strict::Validators::Anything.instance, returns.validator
+      refute returns.coercer
+    end
+
+    it "accepts a combination of all arguments" do
+      returns = Strict::Return.make(Strict::Validators::Boolean.instance, coerce: ->(value) { value + 1 })
+
+      assert_equal Strict::Validators::Boolean.instance, returns.validator
+      assert returns.coercer
+    end
+
+    it "accepts a validator" do
+      returns = Strict::Return.make(Strict::Validators::Boolean.instance)
+
+      assert_equal Strict::Validators::Boolean.instance, returns.validator
+    end
+
+    it "accepts a coerce value" do
+      returns = Strict::Return.make(coerce: ->(value) { value + 1 })
+
+      assert returns.coercer
+    end
+
+    it "does not accept a value for 'default'" do
+      assert_raises(ArgumentError) do
+        Strict::Return.make(default: 1)
+      end
+    end
+
+    it "does not accept a value for 'default_value'" do
+      assert_raises(ArgumentError) do
+        Strict::Return.make(default_value: 1)
+      end
+    end
+
+    it "does not accept a value for 'default_generator'" do
+      assert_raises(ArgumentError) do
+        Strict::Return.make(default_generator: -> { 1 })
+      end
+    end
+  end
+
+  describe "#valid?" do
+    it "uses the validator to check if the value is valid" do
+      returns = Strict::Return.make(Strict::Validators::Boolean.instance)
+
+      assert returns.valid?(true)
+      assert returns.valid?(false)
+      refute returns.valid?(nil)
+      refute returns.valid?(1)
+
+      returns = Strict::Return.make(Strict::Validators::AnyOf.new(Strict::Validators::Boolean.instance, nil))
+
+      assert returns.valid?(true)
+      assert returns.valid?(false)
+      assert returns.valid?(nil)
+      refute returns.valid?(1)
+    end
+  end
+
+  describe "#coerce" do
+    it "returns the value if coercion is not enabled" do
+      returns = Strict::Return.make(coerce: false)
+
+      assert_equal "value", returns.coerce("value")
+    end
+
+    it "does not support .coerce_attr_name coercion" do
+      returns = Strict::Return.make(coerce: true)
+
+      assert_raises(NoMethodError) do
+        returns.coerce("value")
+      end
+    end
+
+    it "does not support coercion methods is passed" do
+      returns = Strict::Return.make(coerce: :some_method)
+
+      assert_raises(NoMethodError) do
+        returns.coerce("value")
+      end
+    end
+
+    it "calls the callable if one is passed" do
+      returns = Strict::Return.make(coerce: ->(value) { "coerced #{value}" })
+
+      assert_equal "coerced value", returns.coerce("value")
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,3 +5,4 @@ require "strict"
 
 require "minitest/autorun"
 require "minitest-spec-context"
+require "debug"


### PR DESCRIPTION
- Extract the validator methods from Attributes::Dsl
- Add missing space to internal error message
- Add a DSL for declaring method signatures
