### PR TITLE
Add Strict::Interface

### DIFF
--- a/lib/strict/implementation_does_not_conform_error.rb
+++ b/lib/strict/implementation_does_not_conform_error.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+module Strict
+  class ImplementationDoesNotConformError < Error
+    attr_reader :interface, :receiver, :missing_methods, :invalid_method_definitions
+
+    def initialize(interface:, receiver:, missing_methods:, invalid_method_definitions:)
+      super(message_from(interface:, receiver:, missing_methods:, invalid_method_definitions:))
+
+      @interface = interface
+      @receiver = receiver
+      @missing_methods = missing_methods
+      @invalid_method_definitions = invalid_method_definitions
+    end
+
+    private
+
+    def message_from(interface:, receiver:, missing_methods:, invalid_method_definitions:)
+      details = [
+        missing_methods_message_from(missing_methods),
+        invalid_method_definitions_message_from(invalid_method_definitions)
+      ].compact.join("\n")
+
+      case receiver
+      when ::Class, ::Module
+        "#{receiver}'s implementation of #{interface} does not conform:\n#{details}"
+      else
+        "#{receiver.class}'s implementation of #{interface} does not conform:\n#{details}"
+      end
+    end
+
+    def missing_methods_message_from(missing_methods)
+      return nil unless missing_methods
+
+      details = missing_methods.map do |method_name|
+        "    - #{method_name}"
+      end.join("\n")
+
+      "  Some methods exposed in the interface were not defined in the implementation:\n#{details}"
+    end
+
+    def invalid_method_definitions_message_from(invalid_method_definitions)
+      return nil if invalid_method_definitions.empty?
+
+      methods_details = invalid_method_definitions.map do |name, invalid_method_definition|
+        method_details = [
+          missing_parameters_message_from(invalid_method_definition.fetch(:missing_parameters)),
+          additional_parameters_message_from(invalid_method_definition.fetch(:additional_parameters)),
+          non_keyword_parameters_message_from(invalid_method_definition.fetch(:non_keyword_parameters))
+        ].compact.join("\n")
+
+        "    #{name}:\n#{method_details}"
+      end.join("\n")
+
+      "  Some methods defined in the implementation did not conform to their interface:\n#{methods_details}"
+    end
+
+    def missing_parameters_message_from(missing_parameters)
+      return nil unless missing_parameters.any?
+
+      details = missing_parameters.map do |parameter_name|
+        "        - #{parameter_name}"
+      end.join("\n")
+
+      "      Some parameters were expected, but were not in the parameter list:\n#{details}"
+    end
+
+    def additional_parameters_message_from(additional_parameters)
+      return nil unless additional_parameters.any?
+
+      details = additional_parameters.map do |parameter_name|
+        "        - #{parameter_name}"
+      end.join("\n")
+
+      "      Some parameters were not expected, but were in the parameter list:\n#{details}"
+    end
+
+    def non_keyword_parameters_message_from(non_keyword_parameters)
+      return nil unless non_keyword_parameters.any?
+
+      details = non_keyword_parameters.map do |parameter_name|
+        "        - #{parameter_name}"
+      end.join("\n")
+
+      "      Some parameters were not keywords, but only keywords are supported:\n#{details}"
+    end
+  end
+end

--- a/lib/strict/interface.rb
+++ b/lib/strict/interface.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Strict
+  module Interface
+    def self.extended(mod)
+      mod.extend(Strict::Method)
+      mod.include(Interfaces::Instance)
+    end
+
+    def expose(method_name, &)
+      sig = sig(&)
+      parameter_list = sig.parameters.map { |parameter| "#{parameter.name}:" }.join(", ")
+
+      module_eval(<<~RUBY, __FILE__, __LINE__ + 1)
+        def #{method_name}(#{parameter_list}, &block)              # def method_name(one:, two:, three:, &block)
+          implementation.#{method_name}(#{parameter_list}, &block) #   implementation.method_name(one:, two:, three:, &block)
+        end                                                        # end
+      RUBY
+    end
+  end
+end

--- a/lib/strict/interfaces/instance.rb
+++ b/lib/strict/interfaces/instance.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module Strict
+  module Interfaces
+    module Instance
+      attr_reader :implementation
+
+      # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
+      def initialize(implementation)
+        missing_methods = nil
+        invalid_method_definitions = Hash.new do |h, k|
+          h[k] = { additional_parameters: [], missing_parameters: [], non_keyword_parameters: [] }
+        end
+
+        self.class.strict_instance_methods.each do |method_name, strict_method|
+          unless implementation.respond_to?(method_name)
+            missing_methods ||= []
+            missing_methods << method_name
+            next
+          end
+
+          expected_parameters = Set.new(strict_method.parameters.map(&:name))
+          defined_parameters = Set.new
+
+          implementation.method(method_name).parameters.each do |kind, parameter_name|
+            next if kind == :block
+
+            if expected_parameters.include?(parameter_name)
+              defined_parameters.add(parameter_name)
+              invalid_method_definitions[method_name][:non_keyword_parameters] << parameter_name if kind != :keyreq
+            else
+              invalid_method_definitions[method_name][:additional_parameters] << parameter_name
+            end
+          end
+
+          missing_parameters = expected_parameters - defined_parameters
+          invalid_method_definitions[method_name][:missing_parameters] = missing_parameters if missing_parameters.any?
+        end
+
+        if missing_methods || !invalid_method_definitions.empty?
+          raise Strict::ImplementationDoesNotConformError.new(
+            interface: self.class,
+            receiver: implementation,
+            missing_methods:,
+            invalid_method_definitions:
+          )
+        end
+
+        @implementation = implementation
+      end
+      # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
+    end
+  end
+end

--- a/lib/strict/method.rb
+++ b/lib/strict/method.rb
@@ -13,6 +13,24 @@ module Strict
       instance.instance_variable_set(:@__strict_method_internal_last_sig_configuration, Methods::Dsl.run(&))
     end
 
+    def strict_class_methods
+      instance = singleton_class? ? self : singleton_class
+      if instance.instance_variable_defined?(:@__strict_method_internal_class_methods)
+        instance.instance_variable_get(:@__strict_method_internal_class_methods)
+      else
+        instance.instance_variable_set(:@__strict_method_internal_class_methods, {})
+      end
+    end
+
+    def strict_instance_methods
+      instance = singleton_class? ? self : singleton_class
+      if instance.instance_variable_defined?(:@__strict_method_internal_instance_methods)
+        instance.instance_variable_get(:@__strict_method_internal_instance_methods)
+      else
+        instance.instance_variable_set(:@__strict_method_internal_instance_methods, {})
+      end
+    end
+
     # rubocop:disable Metrics/MethodLength
     def singleton_method_added(method_name)
       super
@@ -28,6 +46,7 @@ module Strict
         instance: false
       )
       verifiable_method.verify_definition!
+      strict_class_methods[method_name] = verifiable_method
       singleton_class.prepend(Methods::Module.new(verifiable_method))
     end
 
@@ -45,6 +64,7 @@ module Strict
         instance: true
       )
       verifiable_method.verify_definition!
+      strict_instance_methods[method_name] = verifiable_method
       prepend(Methods::Module.new(verifiable_method))
     end
     # rubocop:enable Metrics/MethodLength

--- a/lib/strict/method_definition_error.rb
+++ b/lib/strict/method_definition_error.rb
@@ -30,7 +30,7 @@ module Strict
         "    - #{parameter_name}"
       end.join("\n")
 
-      "  Some parameters were in the `sig`, but were not in the parameter list:\n#{details}"
+      "  Some parameters were in the sig, but were not in the parameter list:\n#{details}"
     end
 
     def additional_parameters_message_from(additional_parameters)
@@ -40,7 +40,7 @@ module Strict
         "    - #{parameter_name}"
       end.join("\n")
 
-      "  Some parameters were not in the `sig`, but were in the parameter list:\n#{details}"
+      "  Some parameters were not in the sig, but were in the parameter list:\n#{details}"
     end
   end
 end

--- a/test/strict/implementation_does_not_conform_error_test.rb
+++ b/test/strict/implementation_does_not_conform_error_test.rb
@@ -1,0 +1,166 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module ImplementationDoesNotConformErrorTest
+  # rubocop:disable Lint/EmptyClass
+  class Interface
+  end
+
+  class Implementation
+  end
+  # rubocop:enable Lint/EmptyClass
+end
+
+describe Strict::ImplementationDoesNotConformError do
+  describe ".new" do
+    it "builds a message with only missing methods" do
+      error = Strict::ImplementationDoesNotConformError.new(
+        interface: ImplementationDoesNotConformErrorTest::Interface,
+        receiver: ImplementationDoesNotConformErrorTest::Implementation,
+        missing_methods: %i[first_method second_method],
+        invalid_method_definitions: {}
+      )
+
+      expected_message = <<~MESSAGE.chomp
+        ImplementationDoesNotConformErrorTest::Implementation's implementation of ImplementationDoesNotConformErrorTest::Interface does not conform:
+          Some methods exposed in the interface were not defined in the implementation:
+            - first_method
+            - second_method
+      MESSAGE
+
+      assert_equal expected_message, error.message
+    end
+
+    it "builds a message with one invalid method definition" do
+      error = Strict::ImplementationDoesNotConformError.new(
+        interface: ImplementationDoesNotConformErrorTest::Interface,
+        receiver: ImplementationDoesNotConformErrorTest::Implementation,
+        missing_methods: nil,
+        invalid_method_definitions: {
+          first_method: { missing_parameters: %i[foo bar], additional_parameters: [], non_keyword_parameters: [] }
+        }
+      )
+
+      expected_message = <<~MESSAGE.chomp
+        ImplementationDoesNotConformErrorTest::Implementation's implementation of ImplementationDoesNotConformErrorTest::Interface does not conform:
+          Some methods defined in the implementation did not conform to their interface:
+            first_method:
+              Some parameters were expected, but were not in the parameter list:
+                - foo
+                - bar
+      MESSAGE
+
+      assert_equal expected_message, error.message
+    end
+
+    it "builds a message with multiple invalid method definitions" do
+      error = Strict::ImplementationDoesNotConformError.new(
+        interface: ImplementationDoesNotConformErrorTest::Interface,
+        receiver: ImplementationDoesNotConformErrorTest::Implementation,
+        missing_methods: nil,
+        invalid_method_definitions: {
+          first_method: { missing_parameters: %i[foo bar], additional_parameters: [], non_keyword_parameters: [] },
+          second_method: { missing_parameters: %i[fizz buzz], additional_parameters: [], non_keyword_parameters: [] }
+        }
+      )
+
+      expected_message = <<~MESSAGE.chomp
+        ImplementationDoesNotConformErrorTest::Implementation's implementation of ImplementationDoesNotConformErrorTest::Interface does not conform:
+          Some methods defined in the implementation did not conform to their interface:
+            first_method:
+              Some parameters were expected, but were not in the parameter list:
+                - foo
+                - bar
+            second_method:
+              Some parameters were expected, but were not in the parameter list:
+                - fizz
+                - buzz
+      MESSAGE
+
+      assert_equal expected_message, error.message
+    end
+
+    it "builds a message with missing, additional, and non-keyword parameters" do
+      error = Strict::ImplementationDoesNotConformError.new(
+        interface: ImplementationDoesNotConformErrorTest::Interface,
+        receiver: ImplementationDoesNotConformErrorTest::Implementation,
+        missing_methods: nil,
+        invalid_method_definitions: {
+          first_method: {
+            missing_parameters: %i[foo bar],
+            additional_parameters: %i[fizz buzz],
+            non_keyword_parameters: %i[bar bat]
+          }
+        }
+      )
+
+      expected_message = <<~MESSAGE.chomp
+        ImplementationDoesNotConformErrorTest::Implementation's implementation of ImplementationDoesNotConformErrorTest::Interface does not conform:
+          Some methods defined in the implementation did not conform to their interface:
+            first_method:
+              Some parameters were expected, but were not in the parameter list:
+                - foo
+                - bar
+              Some parameters were not expected, but were in the parameter list:
+                - fizz
+                - buzz
+              Some parameters were not keywords, but only keywords are supported:
+                - bar
+                - bat
+      MESSAGE
+
+      assert_equal expected_message, error.message
+    end
+
+    it "builds a message with missing methods and missing, additional, and non-keyword parameters for many methods" do
+      error = Strict::ImplementationDoesNotConformError.new(
+        interface: ImplementationDoesNotConformErrorTest::Interface,
+        receiver: ImplementationDoesNotConformErrorTest::Implementation,
+        missing_methods: %i[first_method second_method],
+        invalid_method_definitions: {
+          third_method: {
+            missing_parameters: %i[a b],
+            additional_parameters: %i[c d],
+            non_keyword_parameters: %i[e f]
+          },
+          fourth_method: {
+            missing_parameters: %i[g h],
+            additional_parameters: %i[i j],
+            non_keyword_parameters: %i[k l]
+          }
+        }
+      )
+
+      expected_message = <<~MESSAGE.chomp
+        ImplementationDoesNotConformErrorTest::Implementation's implementation of ImplementationDoesNotConformErrorTest::Interface does not conform:
+          Some methods exposed in the interface were not defined in the implementation:
+            - first_method
+            - second_method
+          Some methods defined in the implementation did not conform to their interface:
+            third_method:
+              Some parameters were expected, but were not in the parameter list:
+                - a
+                - b
+              Some parameters were not expected, but were in the parameter list:
+                - c
+                - d
+              Some parameters were not keywords, but only keywords are supported:
+                - e
+                - f
+            fourth_method:
+              Some parameters were expected, but were not in the parameter list:
+                - g
+                - h
+              Some parameters were not expected, but were in the parameter list:
+                - i
+                - j
+              Some parameters were not keywords, but only keywords are supported:
+                - k
+                - l
+      MESSAGE
+
+      assert_equal expected_message, error.message
+    end
+  end
+end

--- a/test/strict/interface_test.rb
+++ b/test/strict/interface_test.rb
@@ -1,0 +1,144 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module InterfaceTest
+  class Interface
+    extend Strict::Interface
+
+    expose(:first_method) do
+      foo Integer
+      bar String
+      returns String
+    end
+
+    expose(:second_method) do
+      baz String
+      bat Integer
+      returns Integer
+    end
+
+    expose(:third_method) do
+      fizz Integer
+      buzz String
+      returns String
+    end
+  end
+
+  # rubocop:disable Lint/UnusedMethodArgument
+  class BadImplementation
+    def first_method(foo, bar:, extra:, &block)
+      "first_method"
+    end
+
+    def second_method(baz:)
+      2
+    end
+  end
+
+  class GoodImplementation
+    def first_method(foo:, bar:, &block)
+      "1"
+    end
+
+    def second_method(baz:, bat:)
+      2
+    end
+
+    def third_method(fizz:, buzz:)
+      "3"
+    end
+  end
+  # rubocop:enable Lint/UnusedMethodArgument
+end
+
+describe Strict::Interface do
+  before do
+    @interface = Class.new do
+      extend Strict::Interface
+
+      expose(:call) do
+        one String
+        two String
+        returns String
+      end
+    end
+  end
+
+  describe ".new" do
+    it "raises when given a bad implementation" do
+      error = assert_raises(Strict::ImplementationDoesNotConformError) do
+        InterfaceTest::Interface.new(InterfaceTest::BadImplementation.new)
+      end
+
+      assert_match(/first_method/, error.message)
+      assert_match(/second_method/, error.message)
+      assert_match(/third_method/, error.message)
+    end
+
+    it "does not raise when given a good implementation" do
+      interface = InterfaceTest::Interface.new(InterfaceTest::GoodImplementation.new)
+
+      assert_equal "1", interface.first_method(foo: 1, bar: "2")
+      assert_equal 2, interface.second_method(baz: "1", bat: 2)
+      assert_equal "3", interface.third_method(fizz: 1, buzz: "2")
+    end
+
+    it "raises when missing a parameter" do
+      assert_raises(Strict::ImplementationDoesNotConformError) do
+        @interface.new(
+          Class.new do
+            def call(one:); end
+          end.new
+        )
+      end
+    end
+
+    it "raises when given an extra parameter" do
+      assert_raises(Strict::ImplementationDoesNotConformError) do
+        @interface.new(
+          Class.new do
+            def call(one:, two:, three:); end
+          end.new
+        )
+      end
+    end
+
+    it "raises when given a non-keyword parameter" do
+      assert_raises(Strict::ImplementationDoesNotConformError) do
+        @interface.new(
+          Class.new do
+            def call(one, two:); end
+          end.new
+        )
+      end
+    end
+
+    it "raises when missing a method" do
+      assert_raises(Strict::ImplementationDoesNotConformError) do
+        @interface.new(
+          Class.new.new
+        )
+      end
+    end
+
+    it "does not raise when other methods are defined" do
+      @interface.new(
+        Class.new do
+          def call(one:, two:); end
+          def other(one:, two:); end
+        end.new
+      )
+    end
+  end
+
+  describe "exposed methods" do
+    it "behaves like a Strict::Method" do
+      interface = InterfaceTest::Interface.new(InterfaceTest::GoodImplementation.new)
+
+      assert_raises(Strict::MethodCallError) do
+        interface.first_method(foo: "1", bar: "2")
+      end
+    end
+  end
+end

--- a/test/strict/method_definition_error_test.rb
+++ b/test/strict/method_definition_error_test.rb
@@ -22,7 +22,7 @@ describe Strict::MethodDefinitionError do
 
       expected_message = <<~MESSAGE.chomp
         Defining Strict::Methods::VerifiableMethod#instance? failed because:
-          Some parameters were in the `sig`, but were not in the parameter list:
+          Some parameters were in the sig, but were not in the parameter list:
             - one
             - two
       MESSAGE
@@ -39,7 +39,7 @@ describe Strict::MethodDefinitionError do
 
       expected_message = <<~MESSAGE.chomp
         Defining Strict::Methods::VerifiableMethod#instance? failed because:
-          Some parameters were not in the `sig`, but were in the parameter list:
+          Some parameters were not in the sig, but were in the parameter list:
             - one
             - two
       MESSAGE
@@ -56,10 +56,10 @@ describe Strict::MethodDefinitionError do
 
       expected_message = <<~MESSAGE.chomp
         Defining Strict::Methods::VerifiableMethod#instance? failed because:
-          Some parameters were in the `sig`, but were not in the parameter list:
+          Some parameters were in the sig, but were not in the parameter list:
             - one
             - two
-          Some parameters were not in the `sig`, but were in the parameter list:
+          Some parameters were not in the sig, but were in the parameter list:
             - three
             - four
       MESSAGE

--- a/test/strict/method_test.rb
+++ b/test/strict/method_test.rb
@@ -213,7 +213,7 @@ describe Strict::Method do
 
   describe "instance methods" do
     it "only strictly validates methods declared with a sig" do
-      instance = Class.new do
+      klass = Class.new do
         extend Strict::Method
 
         def sigless(baz, bat)
@@ -228,8 +228,11 @@ describe Strict::Method do
         def sigged(baz, bat)
           baz + bat
         end
-      end.new
+      end
+      instance = klass.new
 
+      assert_empty klass.strict_class_methods.keys
+      assert_equal [:sigged], klass.strict_instance_methods.keys
       assert_equal 3, instance.sigless(1, 2)
       assert_equal "12", instance.sigless("1", "2")
 
@@ -259,6 +262,8 @@ describe Strict::Method do
         end
       end
 
+      assert_equal [:sigged], klass.strict_class_methods.keys
+      assert_empty klass.strict_instance_methods.keys
       assert_equal 3, klass.sigless(1, 2)
       assert_equal "12", klass.sigless("1", "2")
 
@@ -290,6 +295,8 @@ describe Strict::Method do
         end
       end
 
+      assert_equal [:sigged], klass.strict_class_methods.keys
+      assert_empty klass.strict_instance_methods.keys
       assert_equal 3, klass.sigless(1, 2)
       assert_equal "12", klass.sigless("1", "2")
 


### PR DESCRIPTION
Closes #18 

- `sig` -> sig
- Track the strict instance and class methods
- Add Strict::Interface for ensuring a passed-in implementation conforms to the defined methods
