### PR TITLE
Expose an interface coercer

### DIFF
--- a/lib/strict/interface.rb
+++ b/lib/strict/interface.rb
@@ -7,6 +7,10 @@ module Strict
       mod.include(Interfaces::Instance)
     end
 
+    def coercer
+      Interfaces::Coercer.new(self)
+    end
+
     def expose(method_name, &block)
       sig = sig(&block)
       parameter_list = sig.parameters.map { |parameter| "#{parameter.name}:" }.join(", ")

--- a/lib/strict/interfaces/coercer.rb
+++ b/lib/strict/interfaces/coercer.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Strict
+  module Interfaces
+    class Coercer
+      attr_reader :interface_class
+
+      def initialize(interface_class)
+        @interface_class = interface_class
+      end
+
+      def call(value)
+        return value if value.nil? || value.instance_of?(interface_class)
+
+        interface_class.new(value)
+      end
+    end
+  end
+end

--- a/test/strict/interface_test.rb
+++ b/test/strict/interface_test.rb
@@ -132,6 +132,28 @@ describe Strict::Interface do
     end
   end
 
+  describe ".coercer" do
+    it "returns nil when coercing nil" do
+      assert_nil InterfaceTest::Interface.coercer.call(nil)
+    end
+
+    it "returns the interface when passed an instance of the interface" do
+      interface = InterfaceTest::Interface.new(InterfaceTest::GoodImplementation.new)
+      assert_equal interface, InterfaceTest::Interface.coercer.call(interface)
+    end
+
+    it "attempts to instantiate the interface otherwise" do
+      interface = InterfaceTest::Interface.coercer.call(InterfaceTest::GoodImplementation.new)
+      assert_equal InterfaceTest::Interface, interface.class
+      assert_equal InterfaceTest::GoodImplementation, interface.implementation.class
+      assert_equal "1", interface.first_method(foo: 1, bar: "2")
+
+      assert_raises(Strict::ImplementationDoesNotConformError) do
+        InterfaceTest::Interface.coercer.call(InterfaceTest::BadImplementation.new)
+      end
+    end
+  end
+
   describe "exposed methods" do
     it "behaves like a Strict::Method" do
       interface = InterfaceTest::Interface.new(InterfaceTest::GoodImplementation.new)


### PR DESCRIPTION
With this, you can `some_interface Interface, coerce: Interface.coercer` and it'll coerce a passed-in implementation into the interface.