### PR TITLE
Permit implementations to splat their arguments if unused

### DIFF
--- a/test/strict/interface_test.rb
+++ b/test/strict/interface_test.rb
@@ -140,6 +140,48 @@ describe Strict::Interface do
         end.new
       )
     end
+
+    it "does not raise when keyword args are entirely splatted" do
+      @interface.new(
+        Class.new do
+          def call(**kwargs); end
+        end.new
+      )
+    end
+
+    it "does not raise when keyword args are partially splatted" do
+      @interface.new(
+        Class.new do
+          def call(one:, **kwargs); end
+        end.new
+      )
+    end
+
+    it "does not raise when non-keyword args are entirely splatted" do
+      @interface.new(
+        Class.new do
+          def call(*args, one:, two:); end
+        end.new
+      )
+    end
+
+    it "raises when non-keyword args are partially splatted" do
+      assert_raises(Strict::ImplementationDoesNotConformError) do
+        @interface.new(
+          Class.new do
+            def call(foo, *args, one:, two:); end
+          end.new
+        )
+      end
+    end
+
+    it "does not raise when non-keyword and keyword args are entirely splatted" do
+      @interface.new(
+        Class.new do
+          def call(*args, **kwargs); end
+        end.new
+      )
+    end
   end
 
   describe ".coercer" do


### PR DESCRIPTION
When writing mocks and passing those to an implementation, often the mocking library will define the methods as `def foo(*args, **kwargs, &block)` such that they can inspect the arguments and assert upon them later. With this change, parameters that are not directly used by the implemented method can be splatted. When calling the implementation through the interface, types of course will still be strictly checked as they are today. This loosens the strictness of `Strict::Interface` slightly in the regard that the method does not have to be an _exact_ match, but rather must be able to be safely called by the interface instance.