### PR TITLE
Prepare fresh Amp orbs for development

### DIFF
--- a/.agents/resume
+++ b/.agents/resume
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf 'No services require resume steps.\n'

--- a/.agents/setup
+++ b/.agents/setup
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+run_step() {
+  local description="$1"
+  shift
+  local started_at="$SECONDS"
+
+  printf '\n==> %s\n' "$description"
+  "$@"
+  printf '<== Finished in %ss\n' "$((SECONDS - started_at))"
+}
+
+install_system_packages() {
+  local packages=(
+    autoconf
+    bison
+    build-essential
+    ca-certificates
+    curl
+    libdb-dev
+    libffi-dev
+    libgdbm-compat-dev
+    libgdbm-dev
+    libncurses-dev
+    libreadline-dev
+    libssl-dev
+    libyaml-dev
+    patch
+    uuid-dev
+    zlib1g-dev
+  )
+  local missing_packages=()
+  local package
+
+  for package in "${packages[@]}"; do
+    if ! dpkg-query -W -f='${Status}' "$package" 2>/dev/null | grep -Fq 'install ok installed'; then
+      missing_packages+=("$package")
+    fi
+  done
+
+  if ((${#missing_packages[@]} == 0)); then
+    printf 'All system packages are already installed.\n'
+    return
+  fi
+
+  local apt=(apt-get)
+  if ((EUID != 0)); then
+    apt=(sudo apt-get)
+  fi
+
+  "${apt[@]}" update
+  DEBIAN_FRONTEND=noninteractive "${apt[@]}" install -y "${missing_packages[@]}"
+}
+
+install_mise() {
+  if [[ -x "$HOME/.local/bin/mise" ]]; then
+    printf 'mise is already installed.\n'
+    return
+  fi
+
+  curl --fail --location --silent --show-error https://mise.run | sh
+}
+
+configure_login_shell() {
+  local profile="$HOME/.bash_profile"
+  local marker='# strict mise toolchain'
+
+  touch "$profile"
+  if grep -Fqx "$marker" "$profile"; then
+    printf 'The login-shell toolchain path is already configured.\n'
+    return
+  fi
+
+  cat >> "$profile" <<'EOF'
+
+# strict mise toolchain
+case ":$PATH:" in
+  *":$HOME/.local/bin:"*) ;;
+  *) export PATH="$HOME/.local/bin:$PATH" ;;
+esac
+case ":$PATH:" in
+  *":$HOME/.local/share/mise/shims:"*) ;;
+  *) export PATH="$HOME/.local/share/mise/shims:$PATH" ;;
+esac
+EOF
+}
+
+run_step 'Install system packages' install_system_packages
+run_step 'Install mise' install_mise
+
+export PATH="$HOME/.local/bin:$PATH"
+
+run_step 'Configure login-shell toolchain access' configure_login_shell
+run_step 'Install the pinned Ruby toolchain' mise install
+
+bundler_version="$(awk '/^BUNDLED WITH$/{getline; gsub(/^[[:space:]]+|[[:space:]]+$/, ""); print}' Gemfile.lock)"
+if ! mise exec -- ruby -e 'exit Gem::Specification.find_all_by_name("bundler", ARGV.fetch(0)).empty? ? 1 : 0' "$bundler_version"; then
+  run_step "Install Bundler $bundler_version" mise exec -- gem install bundler --version "$bundler_version" --no-document
+fi
+
+run_step 'Install gem dependencies' mise exec -- ./bin/setup

--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,6 @@ $RECYCLE.BIN/
 *.lnk
 
 # End of https://www.toptal.com/developers/gitignore/api/ruby,macos,windows,linux
+
+# Amp orb runtime files
+/.amp/portals/


### PR DESCRIPTION
## Summary

- install the pinned Ruby toolchain and gem dependencies in fresh Amp orbs
- persist mise shims for new login shells
- add a fast resume lifecycle script and ignore portal runtime files

## Verification

- ran `.agents/setup` twice; warm setup completed in 0.52 seconds
- ran `.agents/resume`; completed in 0.00 seconds
- confirmed Ruby 3.0.0 and Bundler 2.3.23 in a clean login shell
- ran `bundle exec rake`: 222 tests passed and RuboCop found no offenses
