### PR TITLE
Define the next-major API compatibility boundary

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,3 +27,35 @@ jobs:
         bundler-cache: true
     - name: Run the default task
       run: bundle exec rake
+
+  benchmark:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    name: Benchmark
+    continue-on-error: true
+
+    steps:
+    - uses: actions/checkout@v7
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: "3.3"
+        bundler-cache: true
+    - name: Run benchmarks
+      run: FORMAT=markdown bundle exec rake benchmark | tee benchmark-results.md
+    - name: Publish benchmark summary
+      if: always()
+      run: |
+        if [[ -f benchmark-results.md ]]; then
+          cat benchmark-results.md >> "$GITHUB_STEP_SUMMARY"
+        else
+          echo "The benchmark did not produce results." >> "$GITHUB_STEP_SUMMARY"
+        fi
+    - name: Upload benchmark results
+      if: always()
+      uses: actions/upload-artifact@v7
+      with:
+        name: benchmark-results
+        path: benchmark-results.md
+        if-no-files-found: warn
+        archive: false

--- a/API.md
+++ b/API.md
@@ -1,0 +1,170 @@
+# Supported API
+
+This document defines the compatibility boundary for Strict's next major release. Code inside this boundary is public API. Other reachable Ruby constants, methods, generated modules, and reflection details are implementation details unless this document identifies them as public.
+
+## Capabilities
+
+Bring each Strict capability into a class with `include`:
+
+```ruby
+include Strict::Value
+include Strict::Object
+include Strict::Method
+include Strict::Interface
+```
+
+The former `extend Strict::Method` and `extend Strict::Interface` forms are not part of this major-version API.
+
+### Values and objects
+
+`Strict::Value` and `Strict::Object` add an `attributes` declaration block. Each declaration accepts an attribute name, an optional validator, `coerce:`, and one of `default:`, `default_value:`, or `default_generator:`.
+
+Attribute names can be ordinary identifiers, Ruby reserved words declared through `strict_attribute`, or names ending in `?` or `!`. A mutable object's punctuation writer can be called with `public_send`, for example `object.public_send(:"active?=", false)`.
+
+Both capabilities provide:
+
+- keyword initialization that rejects missing, additional, or invalid attributes;
+- declared readers;
+- coercion before validation;
+- `to_h`, with symbol keys in declaration order;
+- a meaningful `inspect` and pretty-print representation, without a fixed formatting contract;
+- class methods `strict_attributes` and `coercer`.
+
+`Strict::Object` also provides validated writers. It retains Ruby's identity equality and does not provide `with`.
+
+`Strict::Value` does not provide writers. It provides:
+
+- `with(**attributes)`, which returns a validated instance of the same class;
+- `==` and `eql?`, based on exact class and attribute values;
+- `hash`, consistent with `eql?`.
+
+A subclass that does not declare attributes inherits its parent's supported attribute behavior. Attribute redeclaration, multiple `attributes` blocks, generated-method collisions, and subclass attribute replacement or merging are outside the compatibility boundary.
+
+#### Attribute introspection
+
+`strict_attributes` is an ordered `Enumerable`. Each yielded descriptor supports:
+
+- `name`
+- `validator`
+- `optional?`
+
+The descriptor's concrete class and other methods are implementation details.
+
+#### Defaults
+
+- `default: value` uses the value directly.
+- `default: callable` calls it for each default.
+- `default_value: value` preserves the value even when it is callable.
+- `default_generator: callable` calls it for each default.
+
+Only one default option can be present on one declaration.
+
+#### Attribute coercion
+
+`coerce:` accepts:
+
+- a callable;
+- a class method name as a symbol;
+- `true`, which calls the class method `coerce_<attribute>`.
+
+The generated class `coercer` returns `nil` and non-hash-like values unchanged. For hash-like input, it recognizes declared symbol or string keys and initializes the class with those values.
+
+### Signed methods
+
+`Strict::Method` adds `sig`, which applies to the next instance or singleton method definition. A signature supports required and optional positional parameters, `*rest`, required and optional keyword parameters, `**keyrest`, and an optional `returns` declaration. Blocks pass through without validation.
+
+Parameter declarations accept a validator, a callable `coerce:`, and the three default forms described above. `strict_parameter` supports names that cannot be expressed as ordinary calls in the DSL.
+
+Strict verifies that signature names match the method definition. Calls coerce parameters, validate parameters, invoke the method, and validate its return value. A signature with no `returns` declaration accepts any return value.
+
+Inherited signed methods remain validated. A subclass override is unsigned unless the subclass provides a new signature.
+
+The following behavior is outside the compatibility boundary:
+
+- return-value coercion;
+- private or protected signed methods;
+- duplicate parameter declarations;
+- repeated signatures or same-class method redefinition;
+- DSL expression return values;
+- generated wrapper owners, ancestors, parameters, source locations, or other reflection details.
+
+### Interfaces
+
+`Strict::Interface` adds `expose` and `.coercer`. `expose(name) { ... }` defines a validated, keyword-forwarding instance method.
+
+Constructing an interface requires an implementation. The implementation must respond publicly to every exposed method. Its explicit parameters must be the required keywords declared by the interface. A keyword-rest parameter satisfies keyword coverage. Additional ordinary implementation methods, blocks, and a positional-rest parameter do not affect conformance.
+
+Interface instances expose their `implementation`. The class coercer:
+
+- returns `nil` unchanged;
+- returns an instance of that exact interface unchanged;
+- otherwise wraps the value and checks conformance.
+
+Interface subclassing and re-exposing a method are outside the compatibility boundary.
+
+## Validators and coercers
+
+Any object that implements `===` can be a validator. This includes classes, modules, literals, and custom validators.
+
+Attribute and method DSL blocks provide these validator constructors:
+
+- `AllOf(*validators)`
+- `AnyOf(*validators)`
+- `Anything()`
+- `ArrayOf(element_validator)`
+- `Boolean()`
+- `HashOf(key_validator => value_validator)`
+- `RangeOf(element_validator)`
+
+They also provide these coercer constructors:
+
+- `ToArray(with: nil)`
+- `ToHash(with_keys: nil, with_values: nil)`
+
+The constructors' validation and conversion results are public. Their concrete `Strict::Validators::*` and `Strict::Coercers::*` classes, metadata readers, and exact string representations are not public API.
+
+## Configuration
+
+Strict provides:
+
+- `Strict.configuration`
+- `Strict.configure { |configuration| ... }`
+- `Strict.with_overrides(**options) { ... }`
+
+The supported configuration options are `random` and `sample_rate`, with readers and writers. `random` must implement `Random::Formatter`. `sample_rate` must be in the inclusive range from `0` through `1`.
+
+Overrides are local to the current thread, can be nested, and are restored when a block returns or raises. An active override cannot be changed with `Strict.configure`.
+
+Sampling controls validator calls. Coercion, signature-definition checks, and interface conformance checks still run when validation is sampled out.
+
+Direct construction of `Strict::Configuration`, its `validate?` and `to_h` methods, block return values, and configuration object identity are outside the compatibility boundary.
+
+## Exceptions
+
+These exception classes are public and inherit from `Strict::Error`:
+
+- `Strict::AssignmentError`
+- `Strict::InitializationError`
+- `Strict::ImplementationDoesNotConformError`
+- `Strict::MethodCallError`
+- `Strict::MethodDefinitionError`
+- `Strict::MethodReturnError`
+
+Messages identify the failure but their exact wording and formatting are not fixed. Exception constructor signatures are internal.
+
+The supported readers are:
+
+- `AssignmentError#value`
+- `InitializationError#remaining_attributes` and `#missing_attributes`
+- `ImplementationDoesNotConformError#interface`, `#receiver`, `#missing_methods`, and `#invalid_method_definitions`
+- `MethodCallError#remaining_args`, `#remaining_kwargs`, and `#missing_parameters`
+- `MethodDefinitionError#missing_parameters` and `#additional_parameters`
+- `MethodReturnError#value`
+
+Readers that expose attribute, parameter, or method descriptors are internal.
+
+## Constants and implementation details
+
+`Strict::VERSION` is public. `Strict::ISSUE_TRACKER` is internal.
+
+`Strict::Attribute`, `Strict::Parameter`, `Strict::Return`, `strict_class_methods`, and `strict_instance_methods` are internal. The `Strict::Accessor`, `Strict::Reader`, `Strict::Attributes`, `Strict::Dsl`, `Strict::Interfaces`, and `Strict::Methods` namespaces and their contents are also internal.

--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ group :development do
   gem "factory_bot", "~> 6.5"
   gem "gem-release", "~> 2.2"
   gem "rake", "~> 13.4"
+  gem "rbs", "~> 4.1"
   gem "rspec", "~> 3.13"
   gem "rubocop", "~> 1.89"
   gem "rubocop-factory_bot", "~> 2.28"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -129,6 +129,7 @@ DEPENDENCIES
   factory_bot (~> 6.5)
   gem-release (~> 2.2)
   rake (~> 13.4)
+  rbs (~> 4.1)
   rspec (~> 3.13)
   rubocop (~> 1.89)
   rubocop-factory_bot (~> 2.28)

--- a/README.md
+++ b/README.md
@@ -229,6 +229,8 @@ run validations. The `sample_rate` is used in tandem with `random` to determine 
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the specs. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
+Run `bundle exec rake benchmark` to measure baseline timing and allocations for value initialization, verified method calls, interface calls, `to_h`, equality, and hashing. Set `ITERATIONS`, `WARMUP_ITERATIONS`, or `SAMPLES` to change the workload. These benchmarks report measurements only and do not enforce thresholds.
+
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and the created tag, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Stateful.new(some_state: "123") == Stateful.new(some_state: "123")
 
 ```rb
 class UpdateEmail
-  extend Strict::Method
+  include Strict::Method
 
   sig do
     user_id String, coerce: ->(value) { value.to_s }
@@ -114,7 +114,7 @@ UpdateEmail.new.call(user_id: "123", email: "456")
 
 ```rb
 class Storage
-  extend Strict::Interface
+  include Strict::Interface
 
   expose(:write) do
     key String

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ $ gem install strict
 
 ## Usage
 
+See [Supported API](API.md) for the next major release's compatibility boundary.
+
 ### `Strict::Value`
 
 ```rb

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ run validations. The `sample_rate` is used in tandem with `random` to determine 
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the specs. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
-Run `bundle exec rake benchmark` to measure baseline timing and allocations for value initialization, verified method calls, interface calls, `to_h`, equality, and hashing. Set `ITERATIONS`, `WARMUP_ITERATIONS`, or `SAMPLES` to change the workload. These benchmarks report measurements only and do not enforce thresholds.
+Run `bundle exec rake benchmark` to measure baseline timing and allocations for value initialization, verified method calls, interface calls, `to_h`, equality, and hashing. Set `ITERATIONS`, `WARMUP_ITERATIONS`, or `SAMPLES` to change the workload, and set `FORMAT=markdown` to produce a Markdown table. Pull requests publish this table in a non-blocking job summary and upload it as an artifact. These benchmarks report measurements only and do not enforce thresholds.
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and the created tag, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 

--- a/Rakefile
+++ b/Rakefile
@@ -16,7 +16,7 @@ end
 
 desc "Run timing and allocation baselines"
 task :benchmark do
-  sh "bundle exec ruby benchmark/baseline.rb"
+  sh "bundle exec ruby benchmark/baseline.rb", verbose: false
 end
 
 task default: %i[spec rubocop rbs]

--- a/Rakefile
+++ b/Rakefile
@@ -14,4 +14,9 @@ task :rbs do
   sh "bundle exec rbs -I sig validate"
 end
 
+desc "Run timing and allocation baselines"
+task :benchmark do
+  sh "bundle exec ruby benchmark/baseline.rb"
+end
+
 task default: %i[spec rubocop rbs]

--- a/Rakefile
+++ b/Rakefile
@@ -9,4 +9,9 @@ require "rubocop/rake_task"
 
 RuboCop::RakeTask.new
 
-task default: %i[spec rubocop]
+desc "Validate RBS signatures"
+task :rbs do
+  sh "bundle exec rbs -I sig validate"
+end
+
+task default: %i[spec rubocop rbs]

--- a/benchmark/baseline.rb
+++ b/benchmark/baseline.rb
@@ -1,0 +1,146 @@
+# frozen_string_literal: true
+
+require "strict"
+
+module StrictBenchmark
+  BenchmarkCase = Data.define(:name, :operation)
+
+  ITERATIONS = Integer(ENV.fetch("ITERATIONS", "100000"), 10)
+  WARMUP_ITERATIONS = Integer(ENV.fetch("WARMUP_ITERATIONS", "20000"), 10)
+  SAMPLES = Integer(ENV.fetch("SAMPLES", "5"), 10)
+
+  class Value
+    include Strict::Value
+
+    attributes do
+      id Integer
+      name String
+      active Boolean()
+    end
+  end
+
+  class VerifiedMethod
+    include Strict::Method
+
+    sig do
+      value Integer
+      returns Integer
+    end
+    def call(value:) = value
+  end
+
+  class Interface
+    include Strict::Interface
+
+    expose(:call) do
+      value Integer
+      returns Integer
+    end
+  end
+
+  class Implementation
+    def call(value:) = value
+  end
+
+  class << self
+    def run
+      validate_settings!
+      benchmark_cases = build_cases
+      warm_up(benchmark_cases)
+
+      print_header
+      benchmark_cases.each { |benchmark_case| print_result(benchmark_case) }
+    end
+
+    private
+
+    def print_header
+      puts "Ruby #{RUBY_VERSION} (#{RUBY_ENGINE})"
+      puts "Iterations: #{ITERATIONS}; warmup: #{WARMUP_ITERATIONS}; samples: #{SAMPLES}"
+      puts "Operation                      median ns/op     allocations/op"
+    end
+
+    def print_result(benchmark_case)
+      nanoseconds = median(measure_times(benchmark_case.operation)) * 1_000_000_000 / ITERATIONS
+      allocations = measure_allocations(benchmark_case.operation).fdiv(ITERATIONS)
+      puts format(
+        "%<name>-24s %<nanoseconds>18.1f %<allocations>18.3f",
+        name: benchmark_case.name,
+        nanoseconds: nanoseconds,
+        allocations: allocations
+      )
+    end
+
+    def validate_settings!
+      settings = {
+        "ITERATIONS" => ITERATIONS,
+        "WARMUP_ITERATIONS" => WARMUP_ITERATIONS,
+        "SAMPLES" => SAMPLES
+      }
+      invalid_setting = settings.find { |_name, value| value <= 0 }
+      return unless invalid_setting
+
+      name, value = invalid_setting
+      raise ArgumentError, "#{name} must be greater than zero, got #{value}"
+    end
+
+    # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+    def build_cases
+      value = Value.new(id: 1, name: "Strict", active: true)
+      equal_value = Value.new(id: 1, name: "Strict", active: true)
+      verified_method = VerifiedMethod.new
+      interface = Interface.new(Implementation.new)
+
+      [
+        BenchmarkCase.new("value initialization", -> { Value.new(id: 1, name: "Strict", active: true) }),
+        BenchmarkCase.new("verified method call", -> { verified_method.call(value: 1) }),
+        BenchmarkCase.new("interface call", -> { interface.call(value: 1) }),
+        BenchmarkCase.new("to_h", -> { value.to_h }),
+        BenchmarkCase.new("equality", -> { value == equal_value }),
+        BenchmarkCase.new("hashing", -> { value.hash })
+      ]
+    end
+    # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
+
+    def warm_up(benchmark_cases)
+      benchmark_cases.each do |benchmark_case|
+        repeat(WARMUP_ITERATIONS, benchmark_case.operation)
+      end
+    end
+
+    def measure_times(operation)
+      Array.new(SAMPLES) do
+        GC.start
+        started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        repeat(ITERATIONS, operation)
+        Process.clock_gettime(Process::CLOCK_MONOTONIC) - started_at
+      end
+    end
+
+    def measure_allocations(operation)
+      GC.start
+      gc_was_disabled = GC.disable
+      before = GC.stat(:total_allocated_objects)
+      repeat(ITERATIONS, operation)
+      GC.stat(:total_allocated_objects) - before
+    ensure
+      GC.enable unless gc_was_disabled
+    end
+
+    def repeat(iterations, operation)
+      result = nil
+      iterations.times { result = operation.call }
+      result
+    end
+
+    def median(values)
+      sorted = values.sort
+      middle = sorted.length / 2
+      return sorted.fetch(middle) if sorted.length.odd?
+
+      (sorted.fetch(middle - 1) + sorted.fetch(middle)) / 2
+    end
+  end
+end
+
+StrictBenchmark.run

--- a/benchmark/baseline.rb
+++ b/benchmark/baseline.rb
@@ -8,6 +8,8 @@ module StrictBenchmark
   ITERATIONS = Integer(ENV.fetch("ITERATIONS", "100000"), 10)
   WARMUP_ITERATIONS = Integer(ENV.fetch("WARMUP_ITERATIONS", "20000"), 10)
   SAMPLES = Integer(ENV.fetch("SAMPLES", "5"), 10)
+  FORMAT = ENV.fetch("FORMAT", "text")
+  FORMATS = %w[markdown text].freeze
 
   class Value
     include Strict::Value
@@ -42,46 +44,90 @@ module StrictBenchmark
     def call(value:) = value
   end
 
+  class Formatter
+    def initialize(output_format)
+      @output_format = output_format
+    end
+
+    def print_header
+      puts markdown? ? markdown_header : text_header
+    end
+
+    def print_result(name:, nanoseconds:, allocations:)
+      result = if markdown?
+                 markdown_result(name:, nanoseconds:, allocations:)
+               else
+                 text_result(name:, nanoseconds:, allocations:)
+               end
+      puts result
+    end
+
+    private
+
+    attr_reader :output_format
+
+    def markdown? = output_format == "markdown"
+
+    def markdown_header
+      <<~MARKDOWN.chomp
+        ### Strict benchmark
+
+        `Ruby #{RUBY_VERSION} (#{RUBY_ENGINE})`
+
+        Iterations: #{ITERATIONS}; warmup: #{WARMUP_ITERATIONS}; samples: #{SAMPLES}
+
+        | Operation | Median ns/op | Allocations/op |
+        | --- | ---: | ---: |
+      MARKDOWN
+    end
+
+    def text_header
+      <<~TEXT.chomp
+        Ruby #{RUBY_VERSION} (#{RUBY_ENGINE})
+        Iterations: #{ITERATIONS}; warmup: #{WARMUP_ITERATIONS}; samples: #{SAMPLES}
+        Operation                      median ns/op     allocations/op
+      TEXT
+    end
+
+    def markdown_result(name:, nanoseconds:, allocations:)
+      format("| %<name>s | %<nanoseconds>.1f | %<allocations>.3f |", name:, nanoseconds:, allocations:)
+    end
+
+    def text_result(name:, nanoseconds:, allocations:)
+      format("%<name>-24s %<nanoseconds>18.1f %<allocations>18.3f", name:, nanoseconds:, allocations:)
+    end
+  end
+
   class << self
     def run
       validate_settings!
       benchmark_cases = build_cases
       warm_up(benchmark_cases)
+      formatter = Formatter.new(FORMAT)
 
-      print_header
-      benchmark_cases.each { |benchmark_case| print_result(benchmark_case) }
+      formatter.print_header
+      benchmark_cases.each { |benchmark_case| print_result(formatter, benchmark_case) }
     end
 
     private
 
-    def print_header
-      puts "Ruby #{RUBY_VERSION} (#{RUBY_ENGINE})"
-      puts "Iterations: #{ITERATIONS}; warmup: #{WARMUP_ITERATIONS}; samples: #{SAMPLES}"
-      puts "Operation                      median ns/op     allocations/op"
-    end
-
-    def print_result(benchmark_case)
+    def print_result(formatter, benchmark_case)
       nanoseconds = median(measure_times(benchmark_case.operation)) * 1_000_000_000 / ITERATIONS
       allocations = measure_allocations(benchmark_case.operation).fdiv(ITERATIONS)
-      puts format(
-        "%<name>-24s %<nanoseconds>18.1f %<allocations>18.3f",
-        name: benchmark_case.name,
-        nanoseconds: nanoseconds,
-        allocations: allocations
-      )
+      formatter.print_result(name: benchmark_case.name, nanoseconds:, allocations:)
     end
 
     def validate_settings!
-      settings = {
+      {
         "ITERATIONS" => ITERATIONS,
         "WARMUP_ITERATIONS" => WARMUP_ITERATIONS,
         "SAMPLES" => SAMPLES
-      }
-      invalid_setting = settings.find { |_name, value| value <= 0 }
-      return unless invalid_setting
+      }.each do |name, value|
+        raise ArgumentError, "#{name} must be greater than zero, got #{value}" unless value.positive?
+      end
+      return if FORMATS.include?(FORMAT)
 
-      name, value = invalid_setting
-      raise ArgumentError, "#{name} must be greater than zero, got #{value}"
+      raise ArgumentError, "FORMAT must be one of #{FORMATS.join(', ')}, got #{FORMAT.inspect}"
     end
 
     # rubocop:disable Metrics/AbcSize, Metrics/MethodLength

--- a/lib/strict/accessor/module.rb
+++ b/lib/strict/accessor/module.rb
@@ -18,21 +18,25 @@ module Strict
             end                              # end
           RUBY
 
-          module_eval(<<~RUBY, __FILE__, __LINE__ + 1)
-            def #{attribute.name}=(value)                                         # def name=(value)
-              attribute = self.class.strict_attributes.named!(:#{attribute.name}) #   attribute = self.class.strict_attributes.named!(:name)
-              value = attribute.coerce(value, for_class: self.class)              #   value = attribute.coerce(value, for_class: self.class)
-              if attribute.valid?(value)                                          #   if attribute.valid?(value)
-                #{attribute.instance_variable} = value                            #     @instance_variable = value
-              else                                                                #   else
-                raise Strict::AssignmentError.new(                                #     raise Strict::AssignmentError.new(
-                  assignable_class: self.class,                                   #       assignable_class: self.class,
-                  invalid_attribute: attribute,                                   #       invalid_attribute: attribute,
-                  value: value                                                    #       value: value
-                )                                                                 #     )
-              end                                                                 #   end
-            end                                                                   # end
-          RUBY
+          if attribute.name.end_with?("?", "!")
+            define_writer(attribute)
+          else
+            module_eval(<<~RUBY, __FILE__, __LINE__ + 1)
+              def #{attribute.name}=(value)                                         # def name=(value)
+                attribute = self.class.strict_attributes.named!(:#{attribute.name}) #   attribute = self.class.strict_attributes.named!(:name)
+                value = attribute.coerce(value, for_class: self.class)              #   value = attribute.coerce(value, for_class: self.class)
+                if attribute.valid?(value)                                          #   if attribute.valid?(value)
+                  #{attribute.instance_variable} = value                            #     @instance_variable = value
+                else                                                                #   else
+                  raise Strict::AssignmentError.new(                                #     raise Strict::AssignmentError.new(
+                    assignable_class: self.class,                                   #       assignable_class: self.class,
+                    invalid_attribute: attribute,                                   #       invalid_attribute: attribute,
+                    value: value                                                    #       value: value
+                  )                                                                 #     )
+                end                                                                 #   end
+              end                                                                   # end
+            RUBY
+          end
         end
       end
       # rubocop:enable Metrics/MethodLength
@@ -40,6 +44,27 @@ module Strict
       def inspect
         "#<#{self.class} (#{configuration.attributes.map(&:name).join(', ')})>"
       end
+
+      private
+
+      # rubocop:disable Metrics/MethodLength
+      def define_writer(attribute)
+        attribute_name = attribute.name
+        define_method(:"#{attribute_name}=") do |value|
+          descriptor = self.class.strict_attributes.named!(attribute_name)
+          value = descriptor.coerce(value, for_class: self.class)
+          if descriptor.valid?(value)
+            instance_variable_set(descriptor.instance_variable, value)
+          else
+            raise Strict::AssignmentError.new(
+              assignable_class: self.class,
+              invalid_attribute: descriptor,
+              value: value
+            )
+          end
+        end
+      end
+      # rubocop:enable Metrics/MethodLength
     end
   end
 end

--- a/lib/strict/interface.rb
+++ b/lib/strict/interface.rb
@@ -2,33 +2,35 @@
 
 module Strict
   module Interface
-    def self.extended(mod)
-      mod.extend(Strict::Method)
+    def self.included(mod)
+      mod.include(Strict::Method)
       mod.include(Interfaces::Instance)
+      mod.extend(ClassMethods)
     end
 
-    def coercer
-      Interfaces::Coercer.new(self)
-    end
+    module ClassMethods
+      def coercer
+        Interfaces::Coercer.new(self)
+      end
 
-    # rubocop:disable Metrics/MethodLength
-    def expose(method_name, &)
-      sig = sig(&)
-      parameter_list = [
-        *sig.parameters.map { |parameter| "#{parameter.name}:" },
-        "&block"
-      ].join(", ")
-      argument_list = [
-        *sig.parameters.map { |parameter| "#{parameter.name}: #{parameter.name}" },
-        "&block"
-      ].join(", ")
+      # rubocop:disable Metrics/MethodLength
+      def expose(method_name, &)
+        sig = sig(&)
+        parameter_list = [
+          *sig.parameters.map { |parameter| "#{parameter.name}:" },
+          "&block"
+        ].join(", ")
+        argument_list = sig.parameters.map do |parameter|
+          "#{parameter.name.inspect} => binding.local_variable_get(#{parameter.name.inspect})"
+        end.join(", ")
 
-      module_eval(<<~RUBY, __FILE__, __LINE__ + 1)
-        def #{method_name}(#{parameter_list})              # def method_name(one:, two:, three:, &block)
-          implementation.#{method_name}(#{argument_list})  #   implementation.method_name(one: one, two: two, three: three, &block)
-        end                                                # end
-      RUBY
+        module_eval(<<~RUBY, __FILE__, __LINE__ + 1)
+          def #{method_name}(#{parameter_list})                                            # def method_name(one:, two:, &block)
+            implementation.public_send(#{method_name.inspect}, **{#{argument_list}}, &block) #   implementation.public_send(:method_name, **arguments, &block)
+          end                                                                              # end
+        RUBY
+      end
+      # rubocop:enable Metrics/MethodLength
     end
-    # rubocop:enable Metrics/MethodLength
   end
 end

--- a/lib/strict/method.rb
+++ b/lib/strict/method.rb
@@ -2,71 +2,77 @@
 
 module Strict
   module Method
-    def self.extended(mod)
-      return if mod.singleton_class?
-
-      mod.singleton_class.extend(self)
+    def self.included(mod)
+      mod.extend(ClassMethods)
     end
 
-    def sig(&)
-      instance = singleton_class? ? self : singleton_class
-      instance.instance_variable_set(:@__strict_method_internal_last_sig_configuration, Methods::Dsl.run(&))
-    end
+    module ClassMethods
+      def self.extended(mod)
+        return if mod.singleton_class?
 
-    def strict_class_methods
-      instance = singleton_class? ? self : singleton_class
-      if instance.instance_variable_defined?(:@__strict_method_internal_class_methods)
-        instance.instance_variable_get(:@__strict_method_internal_class_methods)
-      else
-        instance.instance_variable_set(:@__strict_method_internal_class_methods, {})
+        mod.singleton_class.extend(self)
       end
-    end
 
-    def strict_instance_methods
-      instance = singleton_class? ? self : singleton_class
-      if instance.instance_variable_defined?(:@__strict_method_internal_instance_methods)
-        instance.instance_variable_get(:@__strict_method_internal_instance_methods)
-      else
-        instance.instance_variable_set(:@__strict_method_internal_instance_methods, {})
+      def sig(&)
+        instance = singleton_class? ? self : singleton_class
+        instance.instance_variable_set(:@__strict_method_internal_last_sig_configuration, Methods::Dsl.run(&))
       end
+
+      def strict_class_methods
+        instance = singleton_class? ? self : singleton_class
+        if instance.instance_variable_defined?(:@__strict_method_internal_class_methods)
+          instance.instance_variable_get(:@__strict_method_internal_class_methods)
+        else
+          instance.instance_variable_set(:@__strict_method_internal_class_methods, {})
+        end
+      end
+
+      def strict_instance_methods
+        instance = singleton_class? ? self : singleton_class
+        if instance.instance_variable_defined?(:@__strict_method_internal_instance_methods)
+          instance.instance_variable_get(:@__strict_method_internal_instance_methods)
+        else
+          instance.instance_variable_set(:@__strict_method_internal_instance_methods, {})
+        end
+      end
+
+      # rubocop:disable Metrics/MethodLength
+      def singleton_method_added(method_name)
+        super
+
+        sig = singleton_class.instance_variable_get(:@__strict_method_internal_last_sig_configuration)
+        singleton_class.instance_variable_set(:@__strict_method_internal_last_sig_configuration, nil)
+        return unless sig
+
+        verifiable_method = Methods::VerifiableMethod.new(
+          method: singleton_class.instance_method(method_name),
+          parameters: sig.parameters,
+          returns: sig.returns,
+          instance: false
+        )
+        verifiable_method.verify_definition!
+        strict_class_methods[method_name] = verifiable_method
+        singleton_class.prepend(Methods::Module.new(verifiable_method))
+      end
+
+      def method_added(method_name)
+        super
+
+        sig = singleton_class.instance_variable_get(:@__strict_method_internal_last_sig_configuration)
+        singleton_class.instance_variable_set(:@__strict_method_internal_last_sig_configuration, nil)
+        return unless sig
+
+        verifiable_method = Methods::VerifiableMethod.new(
+          method: instance_method(method_name),
+          parameters: sig.parameters,
+          returns: sig.returns,
+          instance: true
+        )
+        verifiable_method.verify_definition!
+        strict_instance_methods[method_name] = verifiable_method
+        prepend(Methods::Module.new(verifiable_method))
+      end
+      # rubocop:enable Metrics/MethodLength
     end
-
-    # rubocop:disable Metrics/MethodLength
-    def singleton_method_added(method_name)
-      super
-
-      sig = singleton_class.instance_variable_get(:@__strict_method_internal_last_sig_configuration)
-      singleton_class.instance_variable_set(:@__strict_method_internal_last_sig_configuration, nil)
-      return unless sig
-
-      verifiable_method = Methods::VerifiableMethod.new(
-        method: singleton_class.instance_method(method_name),
-        parameters: sig.parameters,
-        returns: sig.returns,
-        instance: false
-      )
-      verifiable_method.verify_definition!
-      strict_class_methods[method_name] = verifiable_method
-      singleton_class.prepend(Methods::Module.new(verifiable_method))
-    end
-
-    def method_added(method_name)
-      super
-
-      sig = singleton_class.instance_variable_get(:@__strict_method_internal_last_sig_configuration)
-      singleton_class.instance_variable_set(:@__strict_method_internal_last_sig_configuration, nil)
-      return unless sig
-
-      verifiable_method = Methods::VerifiableMethod.new(
-        method: instance_method(method_name),
-        parameters: sig.parameters,
-        returns: sig.returns,
-        instance: true
-      )
-      verifiable_method.verify_definition!
-      strict_instance_methods[method_name] = verifiable_method
-      prepend(Methods::Module.new(verifiable_method))
-    end
-    # rubocop:enable Metrics/MethodLength
   end
 end

--- a/sig/strict.rbs
+++ b/sig/strict.rbs
@@ -1,4 +1,169 @@
 module Strict
   VERSION: String
-  # See the writing guide of rbs: https://github.com/ruby/rbs#guides
+
+  interface _Validator
+    def ===: (untyped value) -> bool
+  end
+
+  interface _Coercer[A, B]
+    def call: (A value) -> B
+  end
+
+  interface _AttributeDescriptor
+    def name: () -> Symbol
+    def validator: () -> _Validator
+    def optional?: () -> bool
+  end
+
+  interface _AttributesInstance
+    def to_h: () -> Hash[Symbol, untyped]
+    def inspect: () -> String
+    def pretty_print: (untyped printer) -> untyped
+  end
+
+  interface _ValidationDsl
+    def AllOf: (*_Validator validators) -> _Validator
+    def AnyOf: (*_Validator validators) -> _Validator
+    def Anything: () -> _Validator
+    def ArrayOf: (_Validator element_validator) -> _Validator
+    def Boolean: () -> _Validator
+    def HashOf: (Hash[_Validator, _Validator] validators) -> _Validator
+    def RangeOf: (_Validator element_validator) -> _Validator
+  end
+
+  interface _CoercionDsl
+    def ToArray: (?with: _Coercer[untyped, untyped]?) -> _Coercer[untyped, Array[untyped]]
+    def ToHash: (?with_keys: _Coercer[untyped, untyped]?, ?with_values: _Coercer[untyped, untyped]?) -> _Coercer[untyped, Hash[untyped, untyped]]
+  end
+
+  type attribute_coercion = bool | Symbol | _Coercer[untyped, untyped]
+  type method_coercion = false | _Coercer[untyped, untyped]
+
+  interface _AttributesDsl
+    include _ValidationDsl
+    include _CoercionDsl
+
+    def strict_attribute: (
+      String | Symbol name,
+      ?_Validator validator,
+      ?coerce: attribute_coercion,
+      ?default: untyped,
+      ?default_value: untyped,
+      ?default_generator: ^() -> untyped
+    ) -> void
+
+    def method_missing: (Symbol name, *untyped arguments, **untyped keywords) -> void
+  end
+
+  interface _MethodDsl
+    include _ValidationDsl
+    include _CoercionDsl
+
+    def strict_parameter: (
+      String | Symbol name,
+      ?_Validator validator,
+      ?coerce: method_coercion,
+      ?default: untyped,
+      ?default_value: untyped,
+      ?default_generator: ^() -> untyped
+    ) -> void
+
+    def returns: (?_Validator validator) -> void
+    def method_missing: (Symbol name, *untyped arguments, **untyped keywords) -> void
+  end
+
+  # Extend this type-only interface in application signatures for classes that
+  # include Strict::Value or Strict::Object.
+  interface _AttributesClass
+    def attributes: () { () [self: _AttributesDsl] -> untyped } -> void
+    def strict_attributes: () -> Enumerable[_AttributeDescriptor]
+    def coercer: () -> _Coercer[untyped, untyped]
+  end
+
+  # Extend this type-only interface in application signatures for classes that
+  # include Strict::Method.
+  interface _MethodClass
+    def sig: () { () [self: _MethodDsl] -> untyped } -> void
+  end
+
+  # Extend this type-only interface in application signatures for classes that
+  # include Strict::Interface.
+  interface _InterfaceClass
+    include _MethodClass
+
+    def expose: (String | Symbol name) { () [self: _MethodDsl] -> untyped } -> void
+    def coercer: () -> _Coercer[untyped, untyped]
+  end
+
+  def self.configuration: () -> Configuration
+  def self.configure: () { (Configuration configuration) -> untyped } -> void
+  def self.with_overrides: (
+    ?random: Random::Formatter,
+    ?sample_rate: Numeric
+  ) { () -> untyped } -> void
+
+  module Value
+    include _AttributesInstance
+
+    def with: (**untyped attributes) -> self
+    def ==: (untyped other) -> bool
+    def eql?: (untyped other) -> bool
+    def hash: () -> Integer
+  end
+
+  module Object
+    include _AttributesInstance
+  end
+
+  module Method
+  end
+
+  module Interface
+    def implementation: () -> untyped
+  end
+
+  class Configuration
+    attr_accessor random: Random::Formatter
+    attr_accessor sample_rate: Numeric
+  end
+
+  class Error < StandardError
+  end
+
+  class AssignmentError < Error
+    def value: () -> untyped
+  end
+
+  class InitializationError < Error
+    def remaining_attributes: () -> Set[Symbol]
+    def missing_attributes: () -> Array[Symbol]?
+  end
+
+  type invalid_method_definition = {
+    additional_parameters: Array[Symbol],
+    missing_parameters: Enumerable[Symbol],
+    non_keyword_parameters: Array[Symbol]
+  }
+
+  class ImplementationDoesNotConformError < Error
+    def interface: () -> Class
+    def receiver: () -> untyped
+    def missing_methods: () -> Array[Symbol]?
+    def invalid_method_definitions: () -> Hash[Symbol, invalid_method_definition]
+  end
+
+  class MethodCallError < Error
+    def remaining_args: () -> Array[untyped]
+    def remaining_kwargs: () -> Hash[Symbol, untyped]
+    def missing_parameters: () -> Array[Symbol]?
+  end
+
+  class MethodDefinitionError < Error
+    def missing_parameters: () -> Enumerable[Symbol]
+    def additional_parameters: () -> Enumerable[Symbol]
+  end
+
+  class MethodReturnError < Error
+    def value: () -> untyped
+  end
 end

--- a/spec/strict/interface_spec.rb
+++ b/spec/strict/interface_spec.rb
@@ -4,7 +4,7 @@ require "spec_helper"
 
 module InterfaceTest
   class Interface
-    extend Strict::Interface
+    include Strict::Interface
 
     expose(:first_method) do
       foo Integer
@@ -63,7 +63,7 @@ end
 RSpec.describe Strict::Interface do
   let(:interface_class) do
     Class.new do
-      extend Strict::Interface
+      include Strict::Interface
 
       expose(:call) do
         one String
@@ -226,5 +226,21 @@ RSpec.describe Strict::Interface do
         interface.first_method(foo: "1", bar: "2")
       end.to raise_error(Strict::MethodCallError)
     end
+  end
+
+  it "supports reserved parameter names through strict_parameter" do
+    interface_class = Class.new do
+      include Strict::Interface
+
+      expose(:call) do
+        strict_parameter :if, String
+        returns String
+      end
+    end
+    implementation = Class.new do
+      class_eval("def call(if:); binding.local_variable_get(:if); end", __FILE__, __LINE__)
+    end.new
+
+    expect(interface_class.new(implementation).call(if: "yes")).to eq("yes")
   end
 end

--- a/spec/strict/method_spec.rb
+++ b/spec/strict/method_spec.rb
@@ -5,7 +5,7 @@ require "spec_helper"
 RSpec.describe Strict::Method do
   it "supports a mix of positional and keyword parameters" do
     instance = Class.new do
-      extend Strict::Method
+      include Strict::Method
 
       sig do
         one Integer
@@ -19,7 +19,7 @@ RSpec.describe Strict::Method do
 
   it "supports rest parameters" do
     instance = Class.new do
-      extend Strict::Method
+      include Strict::Method
 
       sig do
         one Integer
@@ -38,7 +38,7 @@ RSpec.describe Strict::Method do
 
   it "does not validate blocks, but passes them through" do
     instance = Class.new do
-      extend Strict::Method
+      include Strict::Method
 
       sig do
         one Integer
@@ -55,7 +55,7 @@ RSpec.describe Strict::Method do
 
   it "coerces arguments" do
     instance = Class.new do
-      extend Strict::Method
+      include Strict::Method
 
       sig do
         one Integer, coerce: ->(value) { value.to_i }
@@ -71,7 +71,7 @@ RSpec.describe Strict::Method do
 
   it "does not require optional parameters" do
     instance = Class.new do
-      extend Strict::Method
+      include Strict::Method
 
       sig do
         one Integer, default: 1
@@ -87,7 +87,7 @@ RSpec.describe Strict::Method do
 
   it "ignores the defaults on the method itself when the sig has one" do
     instance = Class.new do
-      extend Strict::Method
+      include Strict::Method
 
       sig do
         one Integer, default: 1
@@ -103,7 +103,7 @@ RSpec.describe Strict::Method do
 
   it "invalidates postitional parameters" do
     instance = Class.new do
-      extend Strict::Method
+      include Strict::Method
 
       sig do
         one Integer
@@ -130,7 +130,7 @@ RSpec.describe Strict::Method do
 
   it "invalidates keyword parameters" do
     instance = Class.new do
-      extend Strict::Method
+      include Strict::Method
 
       sig do
         one Integer
@@ -157,7 +157,7 @@ RSpec.describe Strict::Method do
 
   it "invalidates return values" do
     instance = Class.new do
-      extend Strict::Method
+      include Strict::Method
 
       sig do
         one Anything()
@@ -178,7 +178,7 @@ RSpec.describe Strict::Method do
   it "ensures sigs align with methods" do
     expect do
       Class.new do
-        extend Strict::Method
+        include Strict::Method
 
         sig do
           one Anything()
@@ -191,7 +191,7 @@ RSpec.describe Strict::Method do
 
     expect do
       Class.new do
-        extend Strict::Method
+        include Strict::Method
 
         sig do
           one Anything()
@@ -207,7 +207,7 @@ RSpec.describe Strict::Method do
   describe "instance methods" do
     it "only strictly validates methods declared with a sig" do
       klass = Class.new do
-        extend Strict::Method
+        include Strict::Method
 
         def sigless(baz, bat)
           baz + bat
@@ -237,7 +237,7 @@ RSpec.describe Strict::Method do
   describe "self. class methods" do
     it "only strictly validates methods declared with a sig" do
       klass = Class.new do
-        extend Strict::Method
+        include Strict::Method
 
         def self.sigless(baz, bat)
           baz + bat
@@ -266,7 +266,7 @@ RSpec.describe Strict::Method do
   describe "class << self methods" do
     it "only strictly validates methods declared with a sig" do
       klass = Class.new do
-        extend Strict::Method
+        include Strict::Method
 
         class << self
           def sigless(baz, bat)
@@ -292,5 +292,19 @@ RSpec.describe Strict::Method do
       expect(klass.sigged(1, 2)).to eq(3)
       expect { klass.sigged("1", "2") }.to raise_error(Strict::MethodCallError)
     end
+  end
+
+  it "supports reserved parameter names through strict_parameter" do
+    instance = Class.new do
+      include Strict::Method
+
+      sig do
+        strict_parameter :if, String
+        returns String
+      end
+      class_eval("def call(if:); binding.local_variable_get(:if); end", __FILE__, __LINE__)
+    end.new
+
+    expect(instance.call(if: "yes")).to eq("yes")
   end
 end

--- a/spec/strict/object_spec.rb
+++ b/spec/strict/object_spec.rb
@@ -130,4 +130,23 @@ RSpec.describe Strict::Object do
       ObjectClass.coercer.call({})
     end.to raise_error(Strict::InitializationError)
   end
+
+  it "supports predicate and bang attribute names" do
+    object_class = Class.new do
+      include Strict::Object
+
+      attributes do
+        active? Strict::Validators::Boolean.instance
+        dangerous! Strict::Validators::Boolean.instance
+      end
+    end
+    instance = object_class.new(active?: true, dangerous!: false)
+
+    instance.public_send(:"active?=", false)
+    instance.public_send(:"dangerous!=", true)
+
+    expect(instance.active?).to be(false)
+    expect(instance.dangerous!).to be(true)
+    expect(instance.to_h).to eq(active?: false, dangerous!: true)
+  end
 end

--- a/spec/strict/strict_public_api_spec.rb
+++ b/spec/strict/strict_public_api_spec.rb
@@ -1,0 +1,367 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Strict do
+  describe "capability inclusion" do
+    it "adds each capability with include" do
+      value_class = Class.new { include Strict::Value }
+      object_class = Class.new { include Strict::Object }
+      method_class = Class.new { include Strict::Method }
+      interface_class = Class.new { include Strict::Interface }
+
+      expect(value_class).to respond_to(:attributes)
+      expect(object_class).to respond_to(:attributes)
+      expect(method_class).to respond_to(:sig)
+      expect(interface_class).to respond_to(:expose)
+    end
+  end
+
+  describe "values" do
+    it "supports declarations, coercion, defaults, introspection, copying, equality, and hashing" do
+      generated_default = 0
+      callable_value = -> { "callable value" }
+      value_class = Class.new do
+        include Strict::Value
+
+        def self.coerce_count(value) = value.to_i
+        def self.stringify(value) = value.to_s
+
+        attributes do
+          strict_attribute :if, String
+          active? Boolean()
+          count Integer, coerce: true
+          symbol_coerced String, coerce: :stringify
+          callable_coerced Integer, coerce: ->(value) { value.to_i }
+          static_default String, default: "static"
+          generated_default Integer, default: -> { # rubocop:disable Style/Lambda
+            generated_default += 1
+            1
+          }
+          callable_value Anything(), default_value: callable_value
+          explicit_generator String, default_generator: -> { "generated" }
+        end
+      end
+      attributes = {
+        if: "yes",
+        active?: true,
+        count: "1",
+        symbol_coerced: 2,
+        callable_coerced: "3"
+      }
+      value = value_class.new(**attributes)
+      equal_value = value_class.new(**attributes)
+
+      expect(value.to_h).to eq(
+        **attributes,
+        count: 1,
+        symbol_coerced: "2",
+        callable_coerced: 3,
+        static_default: "static",
+        generated_default: 1,
+        callable_value: callable_value,
+        explicit_generator: "generated"
+      )
+      expect(value.public_send(:if)).to eq("yes")
+      expect(value.active?).to be(true)
+      expect(value).to eq(equal_value)
+      expect(value).to eql(equal_value)
+      expect(value.hash).to eq(equal_value.hash)
+      expect(value.with(count: 4).count).to eq(4)
+
+      descriptors = value_class.strict_attributes.to_a
+      expect(descriptors.map(&:name)).to eq(
+        %i[if active? count symbol_coerced callable_coerced static_default generated_default callable_value
+           explicit_generator]
+      )
+      expect(descriptors.first.validator === "a string").to be(true)
+      expect(descriptors.first.optional?).to be(false)
+      expect(descriptors.last.optional?).to be(true)
+
+      expect(value_class.coercer.call(nil)).to be_nil
+      expect(value_class.coercer.call("unchanged")).to eq("unchanged")
+      coerced = value_class.coercer.call(attributes.transform_keys(&:to_s))
+      expect(coerced).to eq(value)
+
+      child_class = Class.new(value_class)
+      child_value = child_class.new(**attributes)
+      equal_child_value = child_class.new(**attributes)
+      expect(child_value).to eq(equal_child_value)
+    end
+  end
+
+  describe "objects" do
+    it "supports validated punctuation writers and retains identity equality" do
+      object_class = Class.new do
+        include Strict::Object
+
+        attributes do
+          active? Boolean()
+          dangerous! Boolean()
+        end
+      end
+      object = object_class.new(active?: true, dangerous!: false)
+      other = object_class.new(active?: true, dangerous!: false)
+
+      object.public_send(:"active?=", false)
+      object.public_send(:"dangerous!=", true)
+
+      expect(object.to_h).to eq(active?: false, dangerous!: true)
+      expect(object).not_to eq(other)
+      expect(object).not_to respond_to(:with)
+      expect do
+        object.public_send(:"active?=", "no")
+      end.to raise_error(Strict::AssignmentError) { |error| expect(error.value).to eq("no") }
+    end
+  end
+
+  describe "validators and coercers" do
+    it "provides the supported constructors inside attribute declarations" do
+      custom_validator = Object.new
+      custom_validator.define_singleton_method(:===) { |value| value == :custom }
+      value_class = Class.new do
+        include Strict::Value
+
+        attributes do
+          all AllOf(Integer, 1..10)
+          any AnyOf(String, nil)
+          anything Anything()
+          array ArrayOf(Integer)
+          boolean Boolean()
+          hash HashOf(Symbol => Integer)
+          range RangeOf(Integer)
+          custom custom_validator
+          coerced_array ArrayOf(String), coerce: ToArray(with: ->(value) { value.to_s })
+          coerced_hash HashOf(String => String), coerce: ToHash(
+            with_keys: ->(value) { value.to_s },
+            with_values: ->(value) { value.to_s }
+          )
+        end
+      end
+      value = value_class.new(
+        all: 5,
+        any: nil,
+        anything: Object.new,
+        array: [1, 2],
+        boolean: false,
+        hash: { one: 1 },
+        range: 1..3,
+        custom: :custom,
+        coerced_array: [1, 2],
+        coerced_hash: { one: 1 }
+      )
+
+      expect(value.coerced_array).to eq(%w[1 2])
+      expect(value.coerced_hash).to eq("one" => "1")
+      expect do
+        value_class.new(
+          all: 11,
+          any: nil,
+          anything: nil,
+          array: [],
+          boolean: true,
+          hash: {},
+          range: 1..3,
+          custom: :custom,
+          coerced_array: [],
+          coerced_hash: {}
+        )
+      end.to raise_error(Strict::InitializationError)
+    end
+  end
+
+  describe "signed methods" do
+    it "supports parameter forms, coercion, defaults, blocks, and singleton methods" do
+      method_class = Class.new do
+        include Strict::Method
+
+        sig do
+          first Integer, coerce: ->(value) { value.to_i }
+          rest Array
+          factor Integer, default: 2
+          options Hash
+          returns Array
+        end
+        def call(first, *rest, factor:, **options, &block)
+          [first, rest, factor, options, block.call]
+        end
+
+        sig do
+          strict_parameter :if, String
+          returns String
+        end
+        singleton_class.class_eval("def reserved(if:); binding.local_variable_get(:if); end", __FILE__, __LINE__)
+      end
+
+      expect(method_class.new.call("1", 2, 3, extra: true) { :block }).to eq(
+        [1, [2, 3], 2, { extra: true }, :block]
+      )
+      expect(method_class.reserved(if: "yes")).to eq("yes")
+    end
+
+    it "keeps inherited signed methods validated and treats unsigned overrides normally" do
+      parent_class = Class.new do
+        include Strict::Method
+
+        sig do
+          value Integer
+          returns Integer
+        end
+        def call(value) = value
+      end
+      inherited_class = Class.new(parent_class)
+      overridden_class = Class.new(parent_class) { def call(value) = value }
+
+      expect(inherited_class.new.call(1)).to eq(1)
+      expect { inherited_class.new.call("1") }.to raise_error(Strict::MethodCallError)
+      expect(overridden_class.new.call("1")).to eq("1")
+    end
+  end
+
+  describe "interfaces" do
+    it "checks implementations, forwards reserved keywords, and exposes coercion and implementation" do
+      interface_class = Class.new do
+        include Strict::Interface
+
+        expose(:call) do
+          strict_parameter :if, String
+          returns String
+        end
+      end
+      implementation = Class.new do
+        class_eval("def call(if:); binding.local_variable_get(:if); end", __FILE__, __LINE__)
+      end.new
+      interface = interface_class.new(implementation)
+
+      expect(interface.implementation).to be(implementation)
+      expect(interface.call(if: "yes")).to eq("yes")
+      expect(interface_class.coercer.call(nil)).to be_nil
+      expect(interface_class.coercer.call(interface)).to be(interface)
+      expect(interface_class.coercer.call(implementation).implementation).to be(implementation)
+
+      receiver = Object.new
+      expect do
+        interface_class.new(receiver)
+      end.to raise_error(Strict::ImplementationDoesNotConformError) { |error|
+        expect(error.interface).to be(interface_class)
+        expect(error.receiver).to be(receiver)
+        expect(error.missing_methods).to eq([:call])
+        expect(error.invalid_method_definitions).to be_empty
+      }
+    end
+  end
+
+  describe "configuration" do
+    it "supports nested thread-local overrides and restores them after errors" do
+      original_sample_rate = described_class.configuration.sample_rate
+      thread_sample_rate = Queue.new
+
+      expect do
+        described_class.with_overrides(sample_rate: 0) do
+          expect(described_class.configuration.sample_rate).to eq(0)
+          described_class.with_overrides(sample_rate: 0.5) do
+            expect(described_class.configuration.sample_rate).to eq(0.5)
+          end
+          expect(described_class.configuration.sample_rate).to eq(0)
+
+          Thread.new { thread_sample_rate << described_class.configuration.sample_rate }.join
+          raise "restore the override"
+        end
+      end.to raise_error(RuntimeError, "restore the override")
+
+      expect(thread_sample_rate.pop).to eq(original_sample_rate)
+      expect(described_class.configuration.sample_rate).to eq(original_sample_rate)
+    end
+
+    it "runs coercion while sampling validator calls out" do
+      validator_calls = 0
+      coercer_calls = 0
+      validator = Object.new
+      validator.define_singleton_method(:===) do |_value|
+        validator_calls += 1
+        false
+      end
+      value_class = Class.new do
+        include Strict::Value
+
+        attributes do
+          value validator, coerce: ->(value) { # rubocop:disable Style/Lambda
+            coercer_calls += 1
+            value.to_s
+          }
+        end
+      end
+
+      described_class.with_overrides(sample_rate: 0) { value_class.new(value: 1) }
+
+      expect(coercer_calls).to eq(1)
+      expect(validator_calls).to eq(0)
+    end
+  end
+
+  describe "exceptions" do
+    it "exposes caller-level initialization readers" do
+      value_class = Class.new do
+        include Strict::Value
+
+        attributes do
+          one Integer
+          two String
+        end
+      end
+
+      expect do
+        value_class.new(one: 1, extra: true)
+      end.to raise_error(Strict::InitializationError) { |error|
+        expect(error).to be_a(Strict::Error)
+        expect(error.remaining_attributes.to_a).to eq([:extra])
+        expect(error.missing_attributes).to eq([:two])
+      }
+    end
+
+    it "exposes caller-level method call and definition readers" do
+      method_class = Class.new do
+        include Strict::Method
+
+        sig do
+          one Integer
+          two String
+        end
+        def call(one, two:); end
+      end
+
+      expect do
+        method_class.new.call(:invalid, :extra, unknown: true)
+      end.to raise_error(Strict::MethodCallError) { |error|
+        expect(error.remaining_args).to eq([:extra])
+        expect(error.remaining_kwargs).to eq(unknown: true)
+        expect(error.missing_parameters).to eq([:two])
+      }
+
+      expect do
+        Class.new do
+          include Strict::Method
+
+          sig { one Integer }
+          def call(two); end
+        end
+      end.to raise_error(Strict::MethodDefinitionError) { |error|
+        expect(error.missing_parameters.to_a).to eq([:one])
+        expect(error.additional_parameters.to_a).to eq([:two])
+      }
+    end
+
+    it "exposes the invalid return value" do
+      method_class = Class.new do
+        include Strict::Method
+
+        sig { returns String }
+        def call = 1
+      end
+
+      expect do
+        method_class.new.call
+      end.to raise_error(Strict::MethodReturnError) { |error| expect(error.value).to eq(1) }
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- standardize all Strict capabilities on Ruby's `include` convention for the next major release
- document and characterize the supported runtime API boundary
- add RBS coverage for the supported surface
- add repeatable timing and allocation baselines
- publish non-blocking benchmark results in pull request job summaries and artifacts

## Verification

- `bundle exec rake` (237 examples, 0 failures; RuboCop clean; RBS validation passed)
- `FORMAT=markdown ITERATIONS=1000 WARMUP_ITERATIONS=100 SAMPLES=3 bundle exec rake benchmark`
- workflow YAML syntax validation

No implementation performance refactors or CI benchmark thresholds are included.
