### PR TITLE
Compile signed method invocation metadata once

### DIFF
--- a/lib/strict/methods/module.rb
+++ b/lib/strict/methods/module.rb
@@ -10,10 +10,12 @@ module Strict
 
         @verifiable_method = verifiable_method
         define_method verifiable_method.name do |*args, **kwargs, &block|
-          args, kwargs = verifiable_method.verify_parameters!(*args, **kwargs)
+          configuration = Strict.configuration
+          verified_arguments = verifiable_method.verify_parameters!(args, kwargs, configuration)
+          args, kwargs = verified_arguments if verified_arguments
 
           super(*args, **kwargs, &block).tap do |value|
-            verifiable_method.verify_returns!(value)
+            verifiable_method.verify_returns!(value, configuration)
           end
         end
       end

--- a/lib/strict/methods/verifiable_method.rb
+++ b/lib/strict/methods/verifiable_method.rb
@@ -34,6 +34,11 @@ module Strict
         @parameters_index = parameters.to_h { |p| [p.name, p] }
         @returns = returns
         @instance = instance
+        @parameter_bindings = compile_parameter_bindings
+        @keyword_parameter_names = parameter_bindings.filter_map do |binding|
+          binding.name if binding.kind == :keyword
+        end.freeze
+        @accepts_keyrest = parameter_bindings.any? { |binding| binding.kind == :keyrest }
       end
 
       def to_s
@@ -42,7 +47,7 @@ module Strict
 
       def verify_definition!
         expected_parameters = Set.new(parameters.map(&:name))
-        defined_parameters = Set.new(method.parameters.filter_map { |kind, name| name unless kind == :block })
+        defined_parameters = Set.new(parameter_bindings.map(&:name))
         return if expected_parameters == defined_parameters
 
         missing_parameters = expected_parameters - defined_parameters
@@ -54,55 +59,86 @@ module Strict
         )
       end
 
-      # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity, Metrics/BlockLength
-      # TODO(kkt): clean this up- it's late, though, and the tests are passing
-      def verify_parameters!(*args, **kwargs)
+      # rubocop:disable Metrics/AbcSize, Metrics/BlockLength, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
+      def verify_parameters!(args, kwargs, configuration)
         invalid_parameters = nil
         missing_parameters = nil
+        verified_args = nil
+        verified_kwargs = nil
+        positional_index = 0
 
-        positional_arguments = []
-        keyword_arguments = {}
+        parameter_bindings.each do |binding|
+          parameter = binding.parameter || parameter_named!(binding.name)
+          positional_start = positional_index
+          original_value = case binding.kind
+                           when :positional
+                             if positional_index < args.length
+                               positional_index += 1
+                               args.fetch(positional_start)
+                             else
+                               NOT_PROVIDED
+                             end
+                           when :optional_positional
+                             if args.length - positional_index > binding.required_after
+                               positional_index += 1
+                               args.fetch(positional_start)
+                             else
+                               NOT_PROVIDED
+                             end
+                           when :rest
+                             count = args.length - positional_index - binding.required_after
+                             count = 0 if count.negative?
+                             positional_index += count
+                             if positional_start.zero? && count == args.length
+                               args
+                             else
+                               args.slice(positional_start, count)
+                             end
+                           when :keyword
+                             kwargs.key?(binding.name) ? kwargs.fetch(binding.name) : NOT_PROVIDED
+                           when :keyrest
+                             keyrest_value(kwargs)
+                           end
 
-        # TODO(kkt): doesn't handle oddly sorted optional positional parameters like def foo(opt = nil, req)
-        method.parameters.each do |kind, name|
-          case kind
-          when POSITIONAL
-            parameter_kind = :positional
-            value = args.any? ? args.shift : NOT_PROVIDED
-          when REST
-            parameter_kind = :rest
-            value = [*args]
-            args.clear
-          when KEYWORD
-            parameter_kind = :keyword
-            value = kwargs.key?(name) ? kwargs.delete(name) : NOT_PROVIDED
-          when KEYREST
-            parameter_kind = :keyrest
-            value = { **kwargs }
-            kwargs.clear
-          end
-          next unless parameter_kind
-
-          parameter = parameter_named!(name)
-          if value.equal?(NOT_PROVIDED) && parameter.optional?
+          if original_value.equal?(NOT_PROVIDED) && parameter.optional?
             value = parameter.default_generator.call
-          elsif value.equal?(NOT_PROVIDED)
+            changed = true
+          elsif original_value.equal?(NOT_PROVIDED)
             missing_parameters ||= []
             missing_parameters << parameter.name
             next
+          else
+            value = original_value
+            changed = false
           end
 
           value = parameter.coerce(value)
-          if parameter.valid?(value)
-            case parameter_kind
-            when :positional
-              positional_arguments << value
+          changed ||= !value.equal?(original_value)
+          if parameter.valid?(value, configuration)
+            case binding.kind
+            when :positional, :optional_positional
+              if verified_args
+                verified_args << value
+              elsif changed
+                verified_args = args.take(positional_start)
+                verified_args << value
+              end
             when :rest
-              positional_arguments.concat(value)
+              if verified_args
+                verified_args.concat(value)
+              elsif rest_changed?(args, positional_start, positional_index, value, parameter.coercer)
+                verified_args = args.take(positional_start)
+                verified_args.concat(value)
+              end
             when :keyword
-              keyword_arguments[name] = value
+              if changed
+                verified_kwargs ||= kwargs.dup
+                verified_kwargs[binding.name] = value
+              end
             when :keyrest
-              keyword_arguments.merge!(value)
+              if keyrest_changed?(kwargs, value, parameter.coercer)
+                verified_kwargs = merge_keyrest(verified_kwargs, kwargs, value)
+              end
             end
           else
             invalid_parameters ||= {}
@@ -110,41 +146,113 @@ module Strict
           end
         end
 
-        if args.empty? && kwargs.empty? && invalid_parameters.nil? && missing_parameters.nil?
-          [positional_arguments, keyword_arguments]
-        else
-          raise Strict::MethodCallError.new(
-            verifiable_method: self,
-            remaining_args: args,
-            remaining_kwargs: kwargs,
-            invalid_parameters: invalid_parameters,
-            missing_parameters: missing_parameters
-          )
-        end
-      end
-      # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity, Metrics/BlockLength
+        if positional_index == args.length && no_additional_keywords?(kwargs) &&
+           invalid_parameters.nil? && missing_parameters.nil?
+          return if verified_args.nil? && verified_kwargs.nil?
 
-      def verify_returns!(value)
+          return [verified_args || args, verified_kwargs || kwargs]
+        end
+
+        raise Strict::MethodCallError.new(
+          verifiable_method: self,
+          remaining_args: args.drop(positional_index),
+          remaining_kwargs: remaining_kwargs_from(kwargs),
+          invalid_parameters: invalid_parameters,
+          missing_parameters: missing_parameters
+        )
+      end
+      # rubocop:enable Metrics/AbcSize, Metrics/BlockLength, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
+
+      def verify_returns!(value, configuration)
         value = returns.coerce(value)
-        return if returns.valid?(value)
+        return if returns.valid?(value, configuration)
 
         raise Strict::MethodReturnError.new(verifiable_method: self, value: value)
       end
 
       private
 
-      POSITIONAL = Set.new(%i[req opt])
-      private_constant :POSITIONAL
-      REST = :rest
-      private_constant :REST
-      KEYWORD = Set.new(%i[keyreq key])
-      private_constant :KEYWORD
-      KEYREST = :keyrest
-      private_constant :KEYREST
+      ParameterBinding = Data.define(:kind, :name, :parameter, :required_after)
+      private_constant :ParameterBinding
+      PARAMETER_KINDS = {
+        req: :positional,
+        opt: :optional_positional,
+        rest: :rest,
+        keyreq: :keyword,
+        key: :keyword,
+        keyrest: :keyrest
+      }.freeze
+      private_constant :PARAMETER_KINDS
       NOT_PROVIDED = ::Object.new.freeze
       private_constant :NOT_PROVIDED
 
-      attr_reader :method, :parameters_index
+      attr_reader :method, :parameters_index, :parameter_bindings, :keyword_parameter_names
+
+      # rubocop:disable Metrics/MethodLength
+      def compile_parameter_bindings
+        required_after = 0
+        method.parameters.reverse_each.filter_map do |kind, name|
+          compiled_kind = PARAMETER_KINDS[kind]
+          next unless compiled_kind
+
+          binding = ParameterBinding.new(
+            kind: compiled_kind,
+            name: name,
+            parameter: parameters_index[name],
+            required_after: required_after
+          )
+          required_after += 1 if kind == :req
+          binding
+        end.reverse.freeze
+      end
+      # rubocop:enable Metrics/MethodLength
+
+      def keyrest_value(kwargs)
+        return kwargs if keyword_parameter_names.empty?
+
+        kwargs.except(*keyword_parameter_names)
+      end
+
+      def rest_changed?(args, start, finish, value, coercer)
+        return true if coercer
+        return false if value.equal?(args)
+        return true unless value.length == finish - start
+
+        value.each_index.any? { |index| !value.fetch(index).equal?(args.fetch(start + index)) }
+      end
+
+      def keyrest_changed?(kwargs, value, coercer)
+        return true if coercer
+        return false if value.equal?(kwargs)
+
+        original_size = 0
+        kwargs.each do |name, original_value|
+          next if keyword_parameter_names.include?(name)
+
+          original_size += 1
+          return true unless value.key?(name) && value.fetch(name).equal?(original_value)
+        end
+        value.size != original_size
+      end
+
+      def merge_keyrest(verified_kwargs, kwargs, value)
+        return value if keyword_parameter_names.empty? && !value.equal?(kwargs)
+        return verified_kwargs if keyword_parameter_names.empty?
+
+        (verified_kwargs || kwargs.dup).delete_if do |name, _value|
+          !keyword_parameter_names.include?(name)
+        end.merge!(value)
+      end
+
+      def no_additional_keywords?(kwargs)
+        @accepts_keyrest || kwargs.none? { |name, _value| !keyword_parameter_names.include?(name) }
+      end
+
+      def remaining_kwargs_from(kwargs)
+        return {} if @accepts_keyrest
+
+        kwargs.except(*keyword_parameter_names)
+      end
 
       def instance?
         @instance

--- a/lib/strict/methods/verifiable_method.rb
+++ b/lib/strict/methods/verifiable_method.rb
@@ -65,6 +65,7 @@ module Strict
         missing_parameters = nil
         verified_args = nil
         verified_kwargs = nil
+        positional_argument_count = args.length
         positional_index = 0
 
         parameter_bindings.each do |binding|
@@ -72,24 +73,24 @@ module Strict
           positional_start = positional_index
           original_value = case binding.kind
                            when :positional
-                             if positional_index < args.length
+                             if positional_index < positional_argument_count
                                positional_index += 1
                                args.fetch(positional_start)
                              else
                                NOT_PROVIDED
                              end
                            when :optional_positional
-                             if args.length - positional_index > binding.required_after
+                             if positional_argument_count - positional_index > binding.required_after
                                positional_index += 1
                                args.fetch(positional_start)
                              else
                                NOT_PROVIDED
                              end
                            when :rest
-                             count = args.length - positional_index - binding.required_after
+                             count = positional_argument_count - positional_index - binding.required_after
                              count = 0 if count.negative?
                              positional_index += count
-                             if positional_start.zero? && count == args.length
+                             if positional_start.zero? && count == positional_argument_count
                                args
                              else
                                args.slice(positional_start, count)
@@ -146,7 +147,7 @@ module Strict
           end
         end
 
-        if positional_index == args.length && no_additional_keywords?(kwargs) &&
+        if positional_index == positional_argument_count && no_additional_keywords?(kwargs) &&
            invalid_parameters.nil? && missing_parameters.nil?
           return if verified_args.nil? && verified_kwargs.nil?
 
@@ -155,7 +156,7 @@ module Strict
 
         raise Strict::MethodCallError.new(
           verifiable_method: self,
-          remaining_args: args.drop(positional_index),
+          remaining_args: args.slice(positional_index, positional_argument_count - positional_index) || [],
           remaining_kwargs: remaining_kwargs_from(kwargs),
           invalid_parameters: invalid_parameters,
           missing_parameters: missing_parameters

--- a/lib/strict/parameter.rb
+++ b/lib/strict/parameter.rb
@@ -55,8 +55,8 @@ module Strict
       @optional
     end
 
-    def valid?(value)
-      return true unless Strict.configuration.validate?
+    def valid?(value, configuration = Strict.configuration)
+      return true unless configuration.validate?
 
       validator === value
     end

--- a/lib/strict/return.rb
+++ b/lib/strict/return.rb
@@ -15,8 +15,8 @@ module Strict
       @coercer = coercer
     end
 
-    def valid?(value)
-      return true unless Strict.configuration.validate?
+    def valid?(value, configuration = Strict.configuration)
+      return true unless configuration.validate?
 
       validator === value
     end

--- a/spec/strict/method_spec.rb
+++ b/spec/strict/method_spec.rb
@@ -36,6 +36,56 @@ RSpec.describe Strict::Method do
     expect(instance.call(1, 2, 3, two: 2.2, other: 1)).to eq([1, [2, 3], 2.2, { other: 1 }])
   end
 
+  it "forwards cardinality changes from an in-place rest coercion" do
+    replacements = [[9], [9, 10, 11]]
+    coercer = ->(values) { values.replace(replacements.shift) }
+    instance = Class.new do
+      include Strict::Method
+
+      sig do
+        values Array, coerce: coercer
+        returns Array
+      end
+      def call(*values) = values
+    end.new
+
+    expect(instance.call(1, 2)).to eq([9])
+    expect(instance.call(1, 2)).to eq([9, 10, 11])
+  end
+
+  it "does not report values added by rest coercion as remaining arguments" do
+    coercer = ->(values) { values.replace([9, 10, 11]) }
+    instance = Class.new do
+      include Strict::Method
+
+      sig { values String, coerce: coercer }
+      def call(*values) = values
+    end.new
+
+    expect do
+      instance.call(1, 2)
+    end.to raise_error(Strict::MethodCallError) { |error| expect(error.remaining_args).to be_empty }
+  end
+
+  it "forwards cardinality changes made by a rest validator" do
+    validator = Object.new
+    validator.define_singleton_method(:===) do |values|
+      values.replace([9])
+      true
+    end
+    instance = Class.new do
+      include Strict::Method
+
+      sig do
+        values validator
+        returns Array
+      end
+      def call(*values) = values
+    end.new
+
+    expect(instance.call(1, 2)).to eq([9])
+  end
+
   it "does not validate blocks, but passes them through" do
     instance = Class.new do
       include Strict::Method

--- a/spec/strict/strict_public_api_spec.rb
+++ b/spec/strict/strict_public_api_spec.rb
@@ -230,6 +230,25 @@ RSpec.describe Strict do
       expect(random_values).to be_empty
     end
 
+    it "supports an optional positional parameter before a required positional parameter" do
+      method_class = Class.new do
+        include Strict::Method
+
+        sig do
+          prefix String, default: "default"
+          value Integer
+          returns Array
+        end
+        # rubocop:disable Style/OptionalArguments
+        def call(prefix = nil, value) = [prefix, value]
+        # rubocop:enable Style/OptionalArguments
+      end
+      method = method_class.new
+
+      expect(method.call(1)).to eq(["default", 1])
+      expect(method.call("given", 1)).to eq(["given", 1])
+    end
+
     it "keeps inherited signed methods validated and treats unsigned overrides normally" do
       parent_class = Class.new do
         include Strict::Method

--- a/spec/strict/strict_public_api_spec.rb
+++ b/spec/strict/strict_public_api_spec.rb
@@ -199,6 +199,37 @@ RSpec.describe Strict do
       expect(method_class.reserved(if: "yes")).to eq("yes")
     end
 
+    it "samples each parameter and the return value independently" do
+      validations = []
+      validator = lambda do |name|
+        Object.new.tap do |value|
+          value.define_singleton_method(:===) do |_argument|
+            validations << name
+            true
+          end
+        end
+      end
+      random_values = [0.25, 0.75, 0.25]
+      random = Object.new.extend(Random::Formatter)
+      random.define_singleton_method(:rand) { random_values.shift }
+      method_class = Class.new do
+        include Strict::Method
+
+        sig do
+          first validator.call(:first)
+          second validator.call(:second)
+          returns validator.call(:return)
+        end
+        def call(first, second) = first + second
+      end
+
+      result = described_class.with_overrides(random: random, sample_rate: 0.5) { method_class.new.call(1, 2) }
+
+      expect(result).to eq(3)
+      expect(validations).to eq(%i[first return])
+      expect(random_values).to be_empty
+    end
+
     it "keeps inherited signed methods validated and treats unsigned overrides normally" do
       parent_class = Class.new do
         include Strict::Method


### PR DESCRIPTION
## Summary

- compile reflected parameter kinds and Strict descriptor bindings when a signed method is defined
- reuse unchanged positional and keyword arguments, allocating replacements only for coercion, signature defaults, or validator mutation
- keep error collections lazy and share one configuration snapshot across each invocation while retaining independent sampling decisions
- support an optional positional parameter before trailing required positional parameters

## Benchmark

Ruby 3.3.12, 100,000 iterations, 20,000 warmup iterations, median of 5 samples:

| Operation | Before | After | Change | Allocations before | Allocations after |
| --- | ---: | ---: | ---: | ---: | ---: |
| verified method call | 2,112.4 ns/op | 1,822.9 ns/op | -13.7% | 10 | 6 |
| interface call | 3,122.4 ns/op | 2,844.3 ns/op | -8.9% | 16 | 11 |

## Verification

- `bundle exec rake` (239 examples, RuboCop, and RBS)
- `bundle exec rake benchmark`