### PR TITLE
Consolidate signed method wrappers by owner

### DIFF
--- a/lib/strict/method.rb
+++ b/lib/strict/method.rb
@@ -52,7 +52,7 @@ module Strict
         )
         verifiable_method.verify_definition!
         strict_class_methods[method_name] = verifiable_method
-        singleton_class.prepend(Methods::Module.new(verifiable_method))
+        strict_method_wrapper(singleton_class).wrap(verifiable_method)
       end
 
       def method_added(method_name)
@@ -70,9 +70,22 @@ module Strict
         )
         verifiable_method.verify_definition!
         strict_instance_methods[method_name] = verifiable_method
-        prepend(Methods::Module.new(verifiable_method))
+        strict_method_wrapper(self).wrap(verifiable_method)
       end
       # rubocop:enable Metrics/MethodLength
+
+      private
+
+      def strict_method_wrapper(owner)
+        if owner.instance_variable_defined?(:@__strict_method_internal_wrapper)
+          owner.instance_variable_get(:@__strict_method_internal_wrapper)
+        else
+          Methods::Module.new.tap do |wrapper|
+            owner.instance_variable_set(:@__strict_method_internal_wrapper, wrapper)
+            owner.prepend(wrapper)
+          end
+        end
+      end
     end
   end
 end

--- a/lib/strict/methods/module.rb
+++ b/lib/strict/methods/module.rb
@@ -3,12 +3,7 @@
 module Strict
   module Methods
     class Module < ::Module
-      attr_reader :verifiable_method
-
-      def initialize(verifiable_method)
-        super()
-
-        @verifiable_method = verifiable_method
+      def wrap(verifiable_method)
         define_method verifiable_method.name do |*args, **kwargs, &block|
           configuration = Strict.configuration
           verified_arguments = verifiable_method.verify_parameters!(args, kwargs, configuration)
@@ -18,10 +13,6 @@ module Strict
             verifiable_method.verify_returns!(value, configuration)
           end
         end
-      end
-
-      def inspect
-        "#<#{self.class} (#{verifiable_method.name})>"
       end
     end
   end

--- a/spec/strict/method_spec.rb
+++ b/spec/strict/method_spec.rb
@@ -344,6 +344,21 @@ RSpec.describe Strict::Method do
     end
   end
 
+  it "reuses one wrapper module for each method owner" do
+    klass = Class.new { include Strict::Method }
+
+    3.times do |index|
+      klass.sig { value Integer }
+      klass.define_method(:"instance_#{index}") { |value| value }
+
+      klass.sig { value Integer }
+      klass.define_singleton_method(:"singleton_#{index}") { |value| value }
+    end
+
+    expect(klass.ancestors.count { |ancestor| ancestor.is_a?(Strict::Methods::Module) }).to eq(1)
+    expect(klass.singleton_class.ancestors.count { |ancestor| ancestor.is_a?(Strict::Methods::Module) }).to eq(1)
+  end
+
   it "supports reserved parameter names through strict_parameter" do
     instance = Class.new do
       include Strict::Method

--- a/spec/strict/strict_public_api_spec.rb
+++ b/spec/strict/strict_public_api_spec.rb
@@ -266,6 +266,28 @@ RSpec.describe Strict do
       expect { inherited_class.new.call("1") }.to raise_error(Strict::MethodCallError)
       expect(overridden_class.new.call("1")).to eq("1")
     end
+
+    it "keeps inherited signed singleton methods validated and treats unsigned overrides normally" do
+      parent_class = Class.new do
+        include Strict::Method
+
+        sig do
+          value Integer
+          returns Integer
+        end
+        def self.call(value) = value
+      end
+      inherited_class = Class.new(parent_class)
+      overridden_class = Class.new(parent_class) do
+        class << self
+          def call(value) = value
+        end
+      end
+
+      expect(inherited_class.call(1)).to eq(1)
+      expect { inherited_class.call("1") }.to raise_error(Strict::MethodCallError)
+      expect(overridden_class.call("1")).to eq("1")
+    end
   end
 
   describe "interfaces" do


### PR DESCRIPTION
## Summary

- reuse one owner-held wrapper module for all signed instance methods and one for all signed singleton methods
- preserve the compiled invocation closures and existing validation behavior for classes and interfaces
- characterize inherited signed singleton validation and unsigned subclass overrides

## Stack

Depends on #91. This PR is based on `compile-method-invocation-metadata`.

## Wrapper growth

With 100 signed methods per owner:

| Owner | Before | After |
| --- | ---: | ---: |
| class instance methods | 100 ancestors | 1 ancestor |
| class singleton methods | 100 ancestors | 1 ancestor |
| interface instance methods | 100 ancestors | 1 ancestor |

## Benchmark

Ruby 3.3.12, 300,000 iterations, 100,000 warmup iterations, median of 9 samples:

| Operation | PR #91 | This change | Allocations before | Allocations after |
| --- | ---: | ---: | ---: | ---: |
| verified method call | 1,806.5 ns/op | 1,807.4 ns/op | 6 | 6 |
| interface call | 2,316.0 ns/op | 2,359.2 ns/op | 11 | 11 |

## Verification

- `bundle exec rake` (241 examples, RuboCop, and RBS)
- `bundle exec rake benchmark`
- extended 9-sample benchmark comparison shown above
