### PR TITLE
Forward interface calls directly from validating wrappers

### DIFF
--- a/lib/strict/interface.rb
+++ b/lib/strict/interface.rb
@@ -13,24 +13,18 @@ module Strict
         Interfaces::Coercer.new(self)
       end
 
-      # rubocop:disable Metrics/MethodLength
       def expose(method_name, &)
-        sig = sig(&)
-        parameter_list = [
-          *sig.parameters.map { |parameter| "#{parameter.name}:" },
-          "&block"
-        ].join(", ")
-        argument_list = sig.parameters.map do |parameter|
-          "#{parameter.name.inspect} => binding.local_variable_get(#{parameter.name.inspect})"
-        end.join(", ")
+        method_name = method_name.to_sym
+        configuration = Methods::Dsl.run(&)
+        verifiable_method = Methods::VerifiableMethod.for_interface(
+          owner: self,
+          name: method_name,
+          configuration: configuration
+        )
 
-        module_eval(<<~RUBY, __FILE__, __LINE__ + 1)
-          def #{method_name}(#{parameter_list})                                            # def method_name(one:, two:, &block)
-            implementation.public_send(#{method_name.inspect}, **{#{argument_list}}, &block) #   implementation.public_send(:method_name, **arguments, &block)
-          end                                                                              # end
-        RUBY
+        strict_instance_methods[method_name] = verifiable_method
+        strict_method_wrapper(self).wrap(verifiable_method, invocation_target: :implementation)
       end
-      # rubocop:enable Metrics/MethodLength
     end
   end
 end

--- a/lib/strict/method.rb
+++ b/lib/strict/method.rb
@@ -44,10 +44,9 @@ module Strict
         singleton_class.instance_variable_set(:@__strict_method_internal_last_sig_configuration, nil)
         return unless sig
 
-        verifiable_method = Methods::VerifiableMethod.new(
+        verifiable_method = Methods::VerifiableMethod.from_method(
           method: singleton_class.instance_method(method_name),
-          parameters: sig.parameters,
-          returns: sig.returns,
+          configuration: sig,
           instance: false
         )
         verifiable_method.verify_definition!
@@ -62,10 +61,9 @@ module Strict
         singleton_class.instance_variable_set(:@__strict_method_internal_last_sig_configuration, nil)
         return unless sig
 
-        verifiable_method = Methods::VerifiableMethod.new(
+        verifiable_method = Methods::VerifiableMethod.from_method(
           method: instance_method(method_name),
-          parameters: sig.parameters,
-          returns: sig.returns,
+          configuration: sig,
           instance: true
         )
         verifiable_method.verify_definition!

--- a/lib/strict/methods/module.rb
+++ b/lib/strict/methods/module.rb
@@ -3,13 +3,39 @@
 module Strict
   module Methods
     class Module < ::Module
-      def wrap(verifiable_method)
+      def wrap(verifiable_method, invocation_target: :super)
+        case invocation_target
+        when :super
+          wrap_super(verifiable_method)
+        when :implementation
+          wrap_implementation(verifiable_method)
+        else
+          raise ArgumentError, "Unknown invocation target: #{invocation_target.inspect}"
+        end
+      end
+
+      private
+
+      def wrap_super(verifiable_method)
         define_method verifiable_method.name do |*args, **kwargs, &block|
           configuration = Strict.configuration
           verified_arguments = verifiable_method.verify_parameters!(args, kwargs, configuration)
           args, kwargs = verified_arguments if verified_arguments
 
           super(*args, **kwargs, &block).tap do |value|
+            verifiable_method.verify_returns!(value, configuration)
+          end
+        end
+      end
+
+      def wrap_implementation(verifiable_method)
+        method_name = verifiable_method.name
+        define_method method_name do |*args, **kwargs, &block|
+          configuration = Strict.configuration
+          verified_arguments = verifiable_method.verify_parameters!(args, kwargs, configuration)
+          args, kwargs = verified_arguments if verified_arguments
+
+          implementation.public_send(method_name, *args, **kwargs, &block).tap do |value|
             verifiable_method.verify_returns!(value, configuration)
           end
         end

--- a/lib/strict/methods/verifiable_method.rb
+++ b/lib/strict/methods/verifiable_method.rb
@@ -13,6 +13,17 @@ module Strict
             instance: instance
           )
         end
+
+        def for_interface(owner:, name:, configuration:)
+          invocation_parameters = configuration.parameters.map { |parameter| [:keyreq, parameter.name] }
+          new(
+            owner: owner,
+            name: name,
+            invocation_parameters: invocation_parameters,
+            configuration: configuration,
+            instance: true
+          )
+        end
       end
 
       class UnknownParameterError < Error

--- a/lib/strict/methods/verifiable_method.rb
+++ b/lib/strict/methods/verifiable_method.rb
@@ -6,20 +6,17 @@ module Strict
       class << self
         def from_method(method:, configuration:, instance:)
           new(
-            owner: method.owner,
-            name: method.name,
-            invocation_parameters: method.parameters,
+            method: method,
             configuration: configuration,
             instance: instance
           )
         end
 
         def for_interface(owner:, name:, configuration:)
-          invocation_parameters = configuration.parameters.map { |parameter| [:keyreq, parameter.name] }
           new(
+            method: nil,
             owner: owner,
             name: name,
-            invocation_parameters: invocation_parameters,
             configuration: configuration,
             instance: true
           )
@@ -43,19 +40,22 @@ module Strict
         end
       end
 
-      attr_reader :name, :parameters, :returns
+      attr_reader :parameters, :returns
 
-      def initialize(owner:, name:, invocation_parameters:, configuration:, instance:)
-        @owner = owner
-        @name = name
+      def initialize(method:, configuration:, instance:, owner: nil, name: nil)
+        @method = method
         @parameters = configuration.parameters
+        @parameters_index = parameters.to_h { |parameter| [parameter.name, parameter] }
         @returns = configuration.returns
         @instance = instance
-        compile_invocation(invocation_parameters)
+        compile_invocation(invocation_parameters_for(method))
+        return if method
+
+        @owner = owner
+        @name = name
       end
 
       def compile_invocation(invocation_parameters)
-        @parameters_index = parameters.to_h { |parameter| [parameter.name, parameter] }
         @parameter_bindings = compile_parameter_bindings(invocation_parameters)
         @keyword_parameter_names = parameter_bindings.filter_map do |binding|
           binding.name if binding.kind == :keyword
@@ -63,6 +63,10 @@ module Strict
         @accepts_keyrest = parameter_bindings.any? { |binding| binding.kind == :keyrest }
       end
       private :compile_invocation
+
+      def name
+        method ? method.name : @name
+      end
 
       def to_s
         "#{owner}#{separator}#{name}"
@@ -210,7 +214,17 @@ module Strict
       NOT_PROVIDED = ::Object.new.freeze
       private_constant :NOT_PROVIDED
 
-      attr_reader :owner, :parameters_index, :parameter_bindings, :keyword_parameter_names
+      attr_reader :method, :parameters_index, :parameter_bindings, :keyword_parameter_names
+
+      def owner
+        method ? method.owner : @owner
+      end
+
+      def invocation_parameters_for(method)
+        return method.parameters if method
+
+        parameters.map { |parameter| [:keyreq, parameter.name] }
+      end
 
       # rubocop:disable Metrics/MethodLength
       def compile_parameter_bindings(invocation_parameters)

--- a/lib/strict/methods/verifiable_method.rb
+++ b/lib/strict/methods/verifiable_method.rb
@@ -1,11 +1,19 @@
 # frozen_string_literal: true
 
-require "forwardable"
-
 module Strict
   module Methods
     class VerifiableMethod # rubocop:disable Metrics/ClassLength
-      extend Forwardable
+      class << self
+        def from_method(method:, configuration:, instance:)
+          new(
+            owner: method.owner,
+            name: method.name,
+            invocation_parameters: method.parameters,
+            configuration: configuration,
+            instance: instance
+          )
+        end
+      end
 
       class UnknownParameterError < Error
         attr_reader :parameter_name
@@ -24,25 +32,29 @@ module Strict
         end
       end
 
-      def_delegator :method, :name
+      attr_reader :name, :parameters, :returns
 
-      attr_reader :parameters, :returns
-
-      def initialize(method:, parameters:, returns:, instance:)
-        @method = method
-        @parameters = parameters
-        @parameters_index = parameters.to_h { |p| [p.name, p] }
-        @returns = returns
+      def initialize(owner:, name:, invocation_parameters:, configuration:, instance:)
+        @owner = owner
+        @name = name
+        @parameters = configuration.parameters
+        @returns = configuration.returns
         @instance = instance
-        @parameter_bindings = compile_parameter_bindings
+        compile_invocation(invocation_parameters)
+      end
+
+      def compile_invocation(invocation_parameters)
+        @parameters_index = parameters.to_h { |parameter| [parameter.name, parameter] }
+        @parameter_bindings = compile_parameter_bindings(invocation_parameters)
         @keyword_parameter_names = parameter_bindings.filter_map do |binding|
           binding.name if binding.kind == :keyword
         end.freeze
         @accepts_keyrest = parameter_bindings.any? { |binding| binding.kind == :keyrest }
       end
+      private :compile_invocation
 
       def to_s
-        "#{method.owner}#{separator}#{name}"
+        "#{owner}#{separator}#{name}"
       end
 
       def verify_definition!
@@ -187,12 +199,12 @@ module Strict
       NOT_PROVIDED = ::Object.new.freeze
       private_constant :NOT_PROVIDED
 
-      attr_reader :method, :parameters_index, :parameter_bindings, :keyword_parameter_names
+      attr_reader :owner, :parameters_index, :parameter_bindings, :keyword_parameter_names
 
       # rubocop:disable Metrics/MethodLength
-      def compile_parameter_bindings
+      def compile_parameter_bindings(invocation_parameters)
         required_after = 0
-        method.parameters.reverse_each.filter_map do |kind, name|
+        invocation_parameters.reverse_each.filter_map do |kind, name|
           compiled_kind = PARAMETER_KINDS[kind]
           next unless compiled_kind
 

--- a/spec/strict/method_call_error_spec.rb
+++ b/spec/strict/method_call_error_spec.rb
@@ -5,10 +5,14 @@ require "spec_helper"
 RSpec.describe Strict::MethodCallError do
   describe ".new" do
     let(:verifiable_method) do
-      Strict::Methods::VerifiableMethod.new(
-        method: Strict::Methods::VerifiableMethod.instance_method(:instance?),
+      method = Strict::Methods::VerifiableMethod.instance_method(:instance?)
+      configuration = Strict::Methods::Configuration.new(
         parameters: [],
-        returns: [],
+        returns: []
+      )
+      Strict::Methods::VerifiableMethod.from_method(
+        method: method,
+        configuration: configuration,
         instance: true
       )
     end

--- a/spec/strict/method_definition_error_spec.rb
+++ b/spec/strict/method_definition_error_spec.rb
@@ -5,10 +5,14 @@ require "spec_helper"
 RSpec.describe Strict::MethodDefinitionError do
   describe ".new" do
     let(:verifiable_method) do
-      Strict::Methods::VerifiableMethod.new(
-        method: Strict::Methods::VerifiableMethod.instance_method(:instance?),
+      method = Strict::Methods::VerifiableMethod.instance_method(:instance?)
+      configuration = Strict::Methods::Configuration.new(
         parameters: [],
-        returns: [],
+        returns: []
+      )
+      Strict::Methods::VerifiableMethod.from_method(
+        method: method,
+        configuration: configuration,
         instance: true
       )
     end

--- a/spec/strict/method_return_error_spec.rb
+++ b/spec/strict/method_return_error_spec.rb
@@ -5,10 +5,14 @@ require "spec_helper"
 RSpec.describe Strict::MethodReturnError do
   describe ".new" do
     let(:verifiable_method) do
-      Strict::Methods::VerifiableMethod.new(
-        method: Strict::Methods::VerifiableMethod.instance_method(:instance?),
+      method = Strict::Methods::VerifiableMethod.instance_method(:instance?)
+      configuration = Strict::Methods::Configuration.new(
         parameters: [],
-        returns: Strict::Return.make(Strict::Validators::AnyOf.new(1, "2", nil)),
+        returns: Strict::Return.make(Strict::Validators::AnyOf.new(1, "2", nil))
+      )
+      Strict::Methods::VerifiableMethod.from_method(
+        method: method,
+        configuration: configuration,
         instance: true
       )
     end

--- a/spec/strict/strict_public_api_spec.rb
+++ b/spec/strict/strict_public_api_spec.rb
@@ -321,6 +321,40 @@ RSpec.describe Strict do
         expect(error.invalid_method_definitions).to be_empty
       }
     end
+
+    it "forwards coerced and defaulted keywords and blocks through punctuation method names" do
+      interface_class = Class.new do
+        include Strict::Interface
+
+        expose(:transform!) do
+          value Integer, coerce: ->(value) { value.to_i }
+          suffix String, default: "!"
+          returns String
+        end
+      end
+      implementation = Class.new do
+        define_method(:transform!) do |value:, suffix:, &block|
+          "#{block.call(value)}#{suffix}"
+        end
+      end.new
+
+      result = interface_class.new(implementation).transform!(value: "2") { |value| value * 3 }
+
+      expect(result).to eq("6!")
+    end
+
+    it "validates exposed method return values" do
+      interface_class = Class.new do
+        include Strict::Interface
+
+        expose(:call) { returns String }
+      end
+      implementation = Class.new { def call = 1 }.new
+
+      expect do
+        interface_class.new(implementation).call
+      end.to raise_error(Strict::MethodReturnError) { |error| expect(error.value).to eq(1) }
+    end
   end
 
   describe "configuration" do

--- a/spec/strict/strict_public_api_spec.rb
+++ b/spec/strict/strict_public_api_spec.rb
@@ -295,18 +295,18 @@ RSpec.describe Strict do
       interface_class = Class.new do
         include Strict::Interface
 
-        expose(:call) do
+        expose(:if) do
           strict_parameter :if, String
           returns String
         end
       end
       implementation = Class.new do
-        class_eval("def call(if:); binding.local_variable_get(:if); end", __FILE__, __LINE__)
+        class_eval("def if(if:); binding.local_variable_get(:if); end", __FILE__, __LINE__)
       end.new
       interface = interface_class.new(implementation)
 
       expect(interface.implementation).to be(implementation)
-      expect(interface.call(if: "yes")).to eq("yes")
+      expect(interface.public_send(:if, if: "yes")).to eq("yes")
       expect(interface_class.coercer.call(nil)).to be_nil
       expect(interface_class.coercer.call(interface)).to be(interface)
       expect(interface_class.coercer.call(implementation).implementation).to be(implementation)
@@ -317,7 +317,7 @@ RSpec.describe Strict do
       end.to raise_error(Strict::ImplementationDoesNotConformError) { |error|
         expect(error.interface).to be(interface_class)
         expect(error.receiver).to be(receiver)
-        expect(error.missing_methods).to eq([:call])
+        expect(error.missing_methods).to eq([:if])
         expect(error.invalid_method_definitions).to be_empty
       }
     end


### PR DESCRIPTION
## Summary

- compile exposed interface contracts directly from the interface DSL and register their keyword invocation metadata at definition time
- install implementation-targeted methods in the existing owner wrapper so calls validate, forward once with `implementation.public_send`, validate the return, and return it
- remove generated interface method source and the pending-`sig` handoff from `expose`
- preserve the existing reflected-method contract layout and characterize reserved and punctuation method names, coercion, defaults, block forwarding, and return failures

## Stack

Depends on #92, which is stacked on #91. This PR is based on `consolidate-signed-method-wrappers`.

## Benchmark

Ruby 3.3.12. The table reports the median result across three extended runs; each run used 300,000 iterations, 100,000 warmup iterations, and 9 samples.

| Operation | PR #92 | This change | Change | Allocations before | Allocations after |
| --- | ---: | ---: | ---: | ---: | ---: |
| verified method call | 2,057.6 ns/op | 1,988.2 ns/op | -3.4% | 6 | 6 |
| interface call | 2,577.5 ns/op | 1,967.8 ns/op | -23.7% | 11 | 8 |

Individual timing runs varied with orb load; allocations were stable. The table uses repeated extended-run medians rather than a single short run.

## Verification

- `bundle exec rake` (243 examples, RuboCop, and RBS)
- `bundle exec rake benchmark`
- extended three-run benchmark comparison shown above
