### PR TITLE
Reduce allocations in value initialization and operations

### DIFF
--- a/lib/strict/attribute.rb
+++ b/lib/strict/attribute.rb
@@ -56,8 +56,8 @@ module Strict
       @optional
     end
 
-    def valid?(value)
-      return true unless Strict.configuration.validate?
+    def valid?(value, configuration = Strict.configuration)
+      return true unless configuration.validate?
 
       validator === value
     end

--- a/lib/strict/attributes/instance.rb
+++ b/lib/strict/attributes/instance.rb
@@ -5,13 +5,14 @@ module Strict
     module Instance
       # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
       def initialize(**attributes)
-        remaining_attributes = Set.new(attributes.keys)
+        initializable_class = self.class
+        configuration = Strict.configuration
         invalid_attributes = nil
         missing_attributes = nil
 
-        self.class.strict_attributes.each do |attribute|
-          if remaining_attributes.delete?(attribute.name)
-            value = attributes.fetch(attribute.name)
+        initializable_class.strict_attributes.each do |attribute|
+          if attributes.key?(attribute.name)
+            value = attributes.delete(attribute.name)
           elsif attribute.optional?
             value = attribute.default_generator.call
           else
@@ -20,8 +21,8 @@ module Strict
             next
           end
 
-          value = attribute.coerce(value, for_class: self.class)
-          if attribute.valid?(value)
+          value = attribute.coerce(value, for_class: initializable_class)
+          if attribute.valid?(value, configuration)
             instance_variable_set(attribute.instance_variable, value)
           else
             invalid_attributes ||= {}
@@ -29,11 +30,11 @@ module Strict
           end
         end
 
-        return if remaining_attributes.none? && invalid_attributes.nil? && missing_attributes.nil?
+        return if attributes.empty? && invalid_attributes.nil? && missing_attributes.nil?
 
         raise InitializationError.new(
-          initializable_class: self.class,
-          remaining_attributes: remaining_attributes,
+          initializable_class: initializable_class,
+          remaining_attributes: Set.new(attributes.keys),
           invalid_attributes: invalid_attributes,
           missing_attributes: missing_attributes
         )

--- a/lib/strict/attributes/instance.rb
+++ b/lib/strict/attributes/instance.rb
@@ -42,9 +42,11 @@ module Strict
       # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
 
       def to_h
-        self.class.strict_attributes.to_h do |attribute|
-          [attribute.name, public_send(attribute.name)]
+        values = {}
+        self.class.strict_attributes.each do |attribute|
+          values[attribute.name] = public_send(attribute.name)
         end
+        values
       end
 
       def inspect

--- a/lib/strict/value.rb
+++ b/lib/strict/value.rb
@@ -11,12 +11,21 @@ module Strict
     end
 
     def eql?(other)
-      self.class.equal?(other.class) && to_h.eql?(other.to_h)
+      return false unless self.class.equal?(other.class)
+
+      self.class.strict_attributes.all? do |attribute|
+        public_send(attribute.name).eql?(other.public_send(attribute.name))
+      end
     end
     alias == eql?
 
     def hash
-      [self.class, to_h].hash
+      value_class = self.class
+      components = [value_class]
+      value_class.strict_attributes.each do |attribute|
+        components << public_send(attribute.name)
+      end
+      components.hash
     end
   end
 end

--- a/spec/strict/strict_public_api_spec.rb
+++ b/spec/strict/strict_public_api_spec.rb
@@ -88,6 +88,21 @@ RSpec.describe Strict do
       equal_child_value = child_class.new(**attributes)
       expect(child_value).to eq(equal_child_value)
     end
+
+    it "derives hashes, equality, and hash codes from declared readers" do
+      value_class = Class.new do
+        include Strict::Value
+
+        attributes { amount Integer }
+      end
+      value_with_overridden_reader = value_class.new(amount: 1)
+      equal_value = value_class.new(amount: 2)
+      value_with_overridden_reader.define_singleton_method(:amount) { 2 }
+
+      expect(value_with_overridden_reader.to_h).to eq(amount: 2)
+      expect(value_with_overridden_reader).to eql(equal_value)
+      expect(value_with_overridden_reader.hash).to eq(equal_value.hash)
+    end
   end
 
   describe "objects" do
@@ -402,6 +417,38 @@ RSpec.describe Strict do
 
       expect(coercer_calls).to eq(1)
       expect(validator_calls).to eq(0)
+    end
+
+    it "samples each attribute independently while retaining coercion and defaults" do
+      validations = []
+      validator = lambda do |name|
+        Object.new.tap do |value|
+          value.define_singleton_method(:===) do |_argument|
+            validations << name
+            true
+          end
+        end
+      end
+      random_values = [0.25, 0.75, 0.25]
+      random = Object.new.extend(Random::Formatter)
+      random.define_singleton_method(:rand) { random_values.shift }
+      value_class = Class.new do
+        include Strict::Value
+
+        attributes do
+          first validator.call(:first)
+          second validator.call(:second), coerce: ->(value) { value.to_s }
+          third validator.call(:third), default: "default"
+        end
+      end
+
+      value = described_class.with_overrides(random: random, sample_rate: 0.5) do
+        value_class.new(first: 1, second: 2)
+      end
+
+      expect(value.to_h).to eq(first: 1, second: "2", third: "default")
+      expect(validations).to eq(%i[first third])
+      expect(random_values).to be_empty
     end
   end
 


### PR DESCRIPTION
## Summary

- consume the method-local keyword hash during value/object initialization and create remaining-attribute state only when raising
- read `Strict.configuration` once per initialization while preserving an independent validation sample for every provided or defaulted attribute
- build `to_h` by direct assignment, compare exact-class values through ordered declared readers, and hash the exact class plus ordered reader values without intermediate hashes
- characterize independent multi-attribute sampling and reader-derived conversion, equality, and hash consistency

## Stack

Depends on #93, which is stacked on #92 and then #91. This PR is based on `direct-interface-forwarders` at exact parent `946d76c4465b0b21927e9a3ce2757424a89e5ad9`.

## Benchmark

Ruby 3.3.12. Each revision used 300,000 iterations, 100,000 warmup iterations, and 9 timing samples.

| Operation | PR #93 ns/op | This change ns/op | Time change | Allocations before | Allocations after |
| --- | ---: | ---: | ---: | ---: | ---: |
| value initialization | 4,488.1 | 2,164.6 | -51.8% | 11 | 4 |
| verified method call | 2,184.8 | 2,104.7 | -3.7% | 6 | 6 |
| interface call | 2,054.4 | 2,053.8 | -0.0% | 8 | 8 |
| to_h | 1,497.9 | 936.7 | -37.5% | 6 | 2 |
| equality | 2,756.8 | 1,670.8 | -39.4% | 12 | 3 |
| hashing | 1,981.5 | 975.9 | -50.7% | 6 | 2 |

## Verification

- `bundle exec rake` (245 examples, RuboCop, and RBS)
- `bundle exec rake benchmark`
- extended parent/head benchmark comparison shown above
