### PR TITLE
Share attribute and parameter declaration invariants

### DIFF
--- a/API.md
+++ b/API.md
@@ -19,7 +19,7 @@ The former `extend Strict::Method` and `extend Strict::Interface` forms are not 
 
 `Strict::Value` and `Strict::Object` add an `attributes` declaration block. Each declaration accepts an attribute name, an optional validator, `coerce:`, and one of `default:`, `default_value:`, or `default_generator:`.
 
-Attribute names can be ordinary identifiers, Ruby reserved words declared through `strict_attribute`, or names ending in `?` or `!`. A mutable object's punctuation writer can be called with `public_send`, for example `object.public_send(:"active?=", false)`.
+Attribute names can be ordinary identifiers, Ruby reserved words declared through `strict_attribute`, or names ending in `?` or `!`. Each distinct name has independent backing storage, including names that differ only by a trailing `?` or `!`. A mutable object's punctuation writer can be called with `public_send`, for example `object.public_send(:"active?=", false)`.
 
 Both capabilities provide:
 

--- a/lib/strict/attribute.rb
+++ b/lib/strict/attribute.rb
@@ -1,65 +1,12 @@
 # frozen_string_literal: true
 
 module Strict
-  class Attribute
-    NOT_PROVIDED = ::Object.new.freeze
-
-    class << self
-      def make(name, validator = Validators::Anything.instance, coerce: false, **defaults)
-        unless valid_defaults?(**defaults)
-          raise ArgumentError, "Only one of 'default', 'default_value', or 'default_generator' can be provided"
-        end
-
-        new(
-          name: name.to_sym,
-          validator: validator,
-          default_generator: make_default_generator(**defaults),
-          coercer: coerce
-        )
-      end
-
-      private
-
-      def valid_defaults?(default: NOT_PROVIDED, default_value: NOT_PROVIDED, default_generator: NOT_PROVIDED)
-        defaults_provided = [default, default_value, default_generator].count do |default_option|
-          !default_option.equal?(NOT_PROVIDED)
-        end
-
-        defaults_provided <= 1
-      end
-
-      def make_default_generator(default: NOT_PROVIDED, default_value: NOT_PROVIDED, default_generator: NOT_PROVIDED)
-        if !default.equal?(NOT_PROVIDED)
-          default.respond_to?(:call) ? default : -> { default }
-        elsif !default_value.equal?(NOT_PROVIDED)
-          -> { default_value }
-        elsif !default_generator.equal?(NOT_PROVIDED)
-          default_generator
-        else
-          NOT_PROVIDED
-        end
-      end
-    end
-
-    attr_reader :name, :validator, :default_generator, :coercer, :instance_variable
+  class Attribute < Declaration
+    attr_reader :instance_variable
 
     def initialize(name:, validator:, default_generator:, coercer:)
-      @name = name.to_sym
-      @validator = validator
-      @default_generator = default_generator
-      @coercer = coercer
-      @optional = !default_generator.equal?(NOT_PROVIDED)
+      super
       @instance_variable = "@#{name.to_s.chomp('!').chomp('?')}"
-    end
-
-    def optional?
-      @optional
-    end
-
-    def valid?(value, configuration = Strict.configuration)
-      return true unless configuration.validate?
-
-      validator === value
     end
 
     def coerce(value, for_class:)

--- a/lib/strict/attribute.rb
+++ b/lib/strict/attribute.rb
@@ -6,7 +6,7 @@ module Strict
 
     def initialize(name:, validator:, default_generator:, coercer:)
       super
-      @instance_variable = "@#{name.to_s.chomp('!').chomp('?')}"
+      @instance_variable = :"@__strict_attribute_#{self.name.to_s.b.unpack1('H*')}"
     end
 
     def coerce(value, for_class:)

--- a/lib/strict/declaration.rb
+++ b/lib/strict/declaration.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+module Strict
+  class Declaration
+    NOT_PROVIDED = ::Object.new.freeze
+
+    class << self
+      def make(name, validator = Validators::Anything.instance, coerce: false, **defaults)
+        unless valid_defaults?(**defaults)
+          raise ArgumentError, "Only one of 'default', 'default_value', or 'default_generator' can be provided"
+        end
+
+        new(
+          name: name.to_sym,
+          validator: validator,
+          default_generator: make_default_generator(**defaults),
+          coercer: coerce
+        )
+      end
+
+      private
+
+      def valid_defaults?(default: NOT_PROVIDED, default_value: NOT_PROVIDED, default_generator: NOT_PROVIDED)
+        defaults_provided = [default, default_value, default_generator].count do |default_option|
+          !default_option.equal?(NOT_PROVIDED)
+        end
+
+        defaults_provided <= 1
+      end
+
+      def make_default_generator(default: NOT_PROVIDED, default_value: NOT_PROVIDED, default_generator: NOT_PROVIDED)
+        if !default.equal?(NOT_PROVIDED)
+          default.respond_to?(:call) ? default : -> { default }
+        elsif !default_value.equal?(NOT_PROVIDED)
+          -> { default_value }
+        elsif !default_generator.equal?(NOT_PROVIDED)
+          default_generator
+        else
+          NOT_PROVIDED
+        end
+      end
+    end
+
+    attr_reader :name, :validator, :default_generator, :coercer
+
+    def initialize(name:, validator:, default_generator:, coercer:)
+      @name = name.to_sym
+      @validator = validator
+      @default_generator = default_generator
+      @coercer = coercer
+      @optional = !default_generator.equal?(NOT_PROVIDED)
+    end
+
+    def optional?
+      @optional
+    end
+
+    def valid?(value, configuration = Strict.configuration)
+      return true unless configuration.validate?
+
+      validator === value
+    end
+  end
+end

--- a/lib/strict/parameter.rb
+++ b/lib/strict/parameter.rb
@@ -1,66 +1,7 @@
 # frozen_string_literal: true
 
 module Strict
-  class Parameter
-    NOT_PROVIDED = ::Object.new.freeze
-
-    class << self
-      def make(name, validator = Validators::Anything.instance, coerce: false, **defaults)
-        unless valid_defaults?(**defaults)
-          raise ArgumentError, "Only one of 'default', 'default_value', or 'default_generator' can be provided"
-        end
-
-        new(
-          name: name.to_sym,
-          validator: validator,
-          default_generator: make_default_generator(**defaults),
-          coercer: coerce
-        )
-      end
-
-      private
-
-      def valid_defaults?(default: NOT_PROVIDED, default_value: NOT_PROVIDED, default_generator: NOT_PROVIDED)
-        defaults_provided = [default, default_value, default_generator].count do |default_option|
-          !default_option.equal?(NOT_PROVIDED)
-        end
-
-        defaults_provided <= 1
-      end
-
-      def make_default_generator(default: NOT_PROVIDED, default_value: NOT_PROVIDED, default_generator: NOT_PROVIDED)
-        if !default.equal?(NOT_PROVIDED)
-          default.respond_to?(:call) ? default : -> { default }
-        elsif !default_value.equal?(NOT_PROVIDED)
-          -> { default_value }
-        elsif !default_generator.equal?(NOT_PROVIDED)
-          default_generator
-        else
-          NOT_PROVIDED
-        end
-      end
-    end
-
-    attr_reader :name, :validator, :default_generator, :coercer
-
-    def initialize(name:, validator:, default_generator:, coercer:)
-      @name = name.to_sym
-      @validator = validator
-      @default_generator = default_generator
-      @coercer = coercer
-      @optional = !default_generator.equal?(NOT_PROVIDED)
-    end
-
-    def optional?
-      @optional
-    end
-
-    def valid?(value, configuration = Strict.configuration)
-      return true unless configuration.validate?
-
-      validator === value
-    end
-
+  class Parameter < Declaration
     def coerce(value)
       return value unless coercer
 

--- a/spec/strict/attribute_spec.rb
+++ b/spec/strict/attribute_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Strict::Attribute do
       expect(attribute.validator).to eq(Strict::Validators::Anything.instance)
       expect(attribute.default_generator).to eq(Strict::Attribute::NOT_PROVIDED)
       expect(attribute.coercer).to be_falsey
-      expect(attribute.instance_variable).to eq("@attr_name")
+      expect(attribute.instance_variable).to eq(:@__strict_attribute_617474725f6e616d65)
       expect(attribute).not_to be_optional
     end
 
@@ -23,7 +23,7 @@ RSpec.describe Strict::Attribute do
       expect(attribute.default_generator).not_to eq(Strict::Attribute::NOT_PROVIDED)
       expect(attribute.default_generator.call).to eq(1)
       expect(attribute.coercer).to be_truthy
-      expect(attribute.instance_variable).to eq("@attr_name")
+      expect(attribute.instance_variable).to eq(:@__strict_attribute_617474725f6e616d65)
       expect(attribute).to be_optional
     end
 

--- a/spec/strict/strict_public_api_spec.rb
+++ b/spec/strict/strict_public_api_spec.rb
@@ -103,6 +103,24 @@ RSpec.describe Strict do
       expect(value_with_overridden_reader).to eql(equal_value)
       expect(value_with_overridden_reader.hash).to eq(equal_value.hash)
     end
+
+    it "stores attribute names with the same stem independently" do
+      value_class = Class.new do
+        include Strict::Value
+
+        attributes do
+          strict_attribute :value, String
+          strict_attribute :value?, Integer
+          strict_attribute :value!, Symbol
+        end
+      end
+      value = value_class.new(value: "plain", value?: 1, value!: :dangerous)
+
+      expect(value.value).to eq("plain")
+      expect(value.value?).to eq(1)
+      expect(value.value!).to eq(:dangerous)
+      expect(value.to_h).to eq(value: "plain", value?: 1, value!: :dangerous)
+    end
   end
 
   describe "objects" do
@@ -127,6 +145,30 @@ RSpec.describe Strict do
       expect do
         object.public_send(:"active?=", "no")
       end.to raise_error(Strict::AssignmentError) { |error| expect(error.value).to eq("no") }
+    end
+
+    it "stores attribute names with the same stem independently" do
+      object_class = Class.new do
+        include Strict::Object
+
+        attributes do
+          strict_attribute :value, String
+          strict_attribute :value?, Integer
+          strict_attribute :value!, Symbol
+        end
+      end
+      object = object_class.new(value: "plain", value?: 1, value!: :dangerous)
+
+      expect(object.to_h).to eq(value: "plain", value?: 1, value!: :dangerous)
+
+      object.value = "changed"
+      object.public_send(:"value?=", 2)
+      object.public_send(:"value!=", :changed)
+
+      expect(object.value).to eq("changed")
+      expect(object.value?).to eq(2)
+      expect(object.value!).to eq(:changed)
+      expect(object.to_h).to eq(value: "changed", value?: 2, value!: :changed)
     end
   end
 


### PR DESCRIPTION
## Summary

- centralize attribute and parameter construction, default handling, shared state, optionality, and validation in one internal declaration owner
- retain attribute-specific coercion and instance-variable ownership in `Strict::Attribute`, and callable coercion in `Strict::Parameter`
- encode each exact attribute name into a pre-resolved internal instance-variable symbol so `value`, `value?`, and `value!` have independent storage without per-instance allocations
- preserve the supported DSL, descriptor introspection, exact default semantics, and per-member configuration sampling

## Stack

PRs #91 through #94 are merged. This PR is now based directly on `main` at exact parent `ea54b716ac30fdf923cf634ba5c257774a3d910f`, the squash merge of #94 and its preceding stack.

## Duplication and size

The shared declaration constructor, three-way default handling, state, optionality, and validation now have one implementation instead of two. Production code remains a net 48 lines smaller (69 insertions and 117 deletions across 3 files). The API and public-boundary tests now guarantee independent storage for distinct same-stem names.

## Benchmark

Ruby 3.3.12. Each revision used 300,000 iterations, 100,000 warmup iterations, and 9 timing samples.

| Operation | `main` ns/op | This change ns/op | Time change | Allocations before | Allocations after |
| --- | ---: | ---: | ---: | ---: | ---: |
| value initialization | 2,139.8 | 2,164.9 | +1.2% | 4 | 4 |
| verified method call | 2,167.4 | 2,163.4 | -0.2% | 6 | 6 |
| interface call | 2,038.7 | 2,040.0 | +0.1% | 8 | 8 |
| to_h | 953.2 | 919.0 | -3.6% | 2 | 2 |
| equality | 1,692.5 | 1,693.5 | +0.1% | 3 | 3 |
| hashing | 969.8 | 990.2 | +2.1% | 2 | 2 |

Allocations are unchanged, and timing differences are within run-to-run noise; there is no material regression. Backing identifiers are resolved to symbols at definition time so initialization does not repeatedly resolve longer encoded strings.

## Verification

- `bundle exec rake` (250 examples, RuboCop, and RBS)
- `bundle exec rake benchmark`
- extended exact-`main`/head benchmark comparison shown above
