### PR TITLE
Isolate Strict override storage

### DIFF
--- a/lib/strict.rb
+++ b/lib/strict.rb
@@ -36,11 +36,11 @@ module Strict
     end
 
     def thread_configuration
-      Thread.current[:configuration]
+      Thread.current[:__strict_configuration_override]
     end
 
     def thread_configuration=(configuration)
-      Thread.current[:configuration] = configuration
+      Thread.current[:__strict_configuration_override] = configuration
     end
 
     def global_configuration

--- a/spec/strict/strict_public_api_spec.rb
+++ b/spec/strict/strict_public_api_spec.rb
@@ -436,6 +436,31 @@ RSpec.describe Strict do
       expect(described_class.configuration.sample_rate).to eq(original_sample_rate)
     end
 
+    it "isolates overrides from application thread-local configuration" do
+      global_configuration = described_class.configuration
+      application_configuration = Object.new
+      original_application_configuration = Thread.current[:configuration]
+      Thread.current[:configuration] = application_configuration
+
+      begin
+        expect(described_class.configuration).to be(global_configuration)
+        expect(described_class.configure { |configuration| configuration }).to be(global_configuration)
+
+        described_class.with_overrides(sample_rate: 0) do
+          expect(described_class.configuration.sample_rate).to eq(0)
+          described_class.with_overrides(sample_rate: 0.5) do
+            expect(described_class.configuration.sample_rate).to eq(0.5)
+          end
+          expect(described_class.configuration.sample_rate).to eq(0)
+        end
+
+        expect(described_class.configuration).to be(global_configuration)
+        expect(Thread.current[:configuration]).to be(application_configuration)
+      ensure
+        Thread.current[:configuration] = original_application_configuration
+      end
+    end
+
     it "runs coercion while sampling validator calls out" do
       validator_calls = 0
       coercer_calls = 0


### PR DESCRIPTION
## Summary

- store Strict configuration overrides under the namespaced `Thread.current[:__strict_configuration_override]` key instead of the generic `:configuration` key
- add a public-boundary regression for `Strict.configuration`, `Strict.configure`, and nested `Strict.with_overrides` while an application owns `Thread.current[:configuration]`
- retain the existing `Thread.current[...]` mechanism and its nesting, restoration, and propagation semantics

## Ancestry

The former #91–#95 parent stack is merged into `main`. This PR is based directly on merged #95 at exact parent `ce9d170473e902fc896bcdc679f93c05886e2848` and contains one focused commit.

## Verification

- `bundle exec rake` (251 examples, RuboCop, and RBS)
- `bundle exec rake benchmark`
- exact-parent/head allocation comparison shown below

## Benchmark

Ruby 3.3.12. Each revision used 100,000 iterations, 20,000 warmup iterations, and 5 timing samples.

| Operation | Parent allocations/op | This change allocations/op |
| --- | ---: | ---: |
| value initialization | 4.000 | 4.000 |
| verified method call | 6.000 | 6.000 |
| interface call | 8.000 | 8.000 |
| to_h | 2.000 | 2.000 |
| equality | 3.000 | 3.000 |
| hashing | 2.000 | 2.000 |

Allocations are unchanged for every benchmark operation.