### PR TITLE
Compile interface conformance expectations once

### DIFF
--- a/benchmark/baseline.rb
+++ b/benchmark/baseline.rb
@@ -144,12 +144,14 @@ module StrictBenchmark
       equal_value = Value.new(id: 1, name: "Strict", active: true)
       mutable = Mutable.new(value: 1)
       verified_method = VerifiedMethod.new
-      interface = Interface.new(Implementation.new)
+      implementation = Implementation.new
+      interface = Interface.new(implementation)
 
       [
         BenchmarkCase.new("value initialization", -> { Value.new(id: 1, name: "Strict", active: true) }),
         BenchmarkCase.new("mutable assignment", -> { mutable.value = 1 }),
         BenchmarkCase.new("verified method call", -> { verified_method.call(value: 1) }),
+        BenchmarkCase.new("interface construction", -> { Interface.new(implementation) }),
         BenchmarkCase.new("interface call", -> { interface.call(value: 1) }),
         BenchmarkCase.new("to_h", -> { value.to_h }),
         BenchmarkCase.new("equality", -> { value == equal_value }),

--- a/lib/strict/interface.rb
+++ b/lib/strict/interface.rb
@@ -13,6 +13,10 @@ module Strict
         Interfaces::Coercer.new(self)
       end
 
+      def strict_interface_conformance
+        @strict_interface_conformance ||= Interfaces::Conformance.new(self)
+      end
+
       def expose(method_name, &)
         method_name = method_name.to_sym
         configuration = Methods::Dsl.run(&)
@@ -23,6 +27,7 @@ module Strict
         )
 
         strict_instance_methods[method_name] = verifiable_method
+        strict_interface_conformance.compile(verifiable_method)
         strict_method_wrapper(self).wrap(verifiable_method, invocation_target: :implementation)
       end
     end

--- a/lib/strict/interfaces/conformance.rb
+++ b/lib/strict/interfaces/conformance.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+module Strict
+  module Interfaces
+    class Conformance
+      def initialize(interface)
+        @interface = interface
+        @method_expectations = []
+      end
+
+      def compile(verifiable_method)
+        parameter_names = verifiable_method.parameters.map(&:name).freeze
+
+        method_expectations << MethodExpectation.new(
+          name: verifiable_method.name,
+          parameter_names: parameter_names
+        )
+      end
+
+      def verify!(receiver)
+        errors = errors_for(receiver)
+        return unless errors
+
+        missing_methods, invalid_method_definitions = errors
+        raise Strict::ImplementationDoesNotConformError.new(
+          interface: interface,
+          receiver: receiver,
+          missing_methods: missing_methods,
+          invalid_method_definitions: invalid_method_definitions
+        )
+      end
+
+      private
+
+      MethodExpectation = Data.define(:name, :parameter_names)
+      private_constant :MethodExpectation
+
+      attr_reader :interface, :method_expectations
+
+      # rubocop:disable Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
+      def errors_for(receiver)
+        missing_methods = nil
+        invalid_method_definitions = nil
+
+        method_expectations.each do |expectation|
+          unless receiver.respond_to?(expectation.name)
+            (missing_methods ||= []) << expectation.name
+            next
+          end
+
+          invalid_definition = invalid_definition_for(expectation, receiver.method(expectation.name).parameters)
+          next unless invalid_definition
+
+          (invalid_method_definitions ||= {})[expectation.name] = invalid_definition
+        end
+
+        return unless missing_methods || invalid_method_definitions
+
+        [missing_methods, invalid_method_definitions || {}]
+      end
+
+      # rubocop:enable Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
+
+      # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
+      def invalid_definition_for(expectation, implementation_parameters)
+        defined_parameter_count = 0
+        has_keyword_splat = false
+        additional_parameters = nil
+        non_keyword_parameters = nil
+
+        implementation_parameters.each do |kind, parameter_name|
+          case kind
+          when :block, :rest
+            next
+          when :keyrest
+            has_keyword_splat = true
+            next
+          end
+
+          unless expectation.parameter_names.include?(parameter_name)
+            (additional_parameters ||= []) << parameter_name
+            next
+          end
+
+          defined_parameter_count += 1
+          (non_keyword_parameters ||= []) << parameter_name unless kind == :keyreq
+        end
+
+        unless has_keyword_splat
+          missing_parameters = missing_parameters_from(
+            expectation,
+            implementation_parameters,
+            defined_parameter_count
+          )
+        end
+        return unless missing_parameters || additional_parameters || non_keyword_parameters
+
+        {
+          additional_parameters: additional_parameters || [],
+          missing_parameters: missing_parameters || [],
+          non_keyword_parameters: non_keyword_parameters || []
+        }
+      end
+      # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
+
+      def missing_parameters_from(expectation, implementation_parameters, defined_parameter_count)
+        return if defined_parameter_count == expectation.parameter_names.length
+
+        Set.new(expectation.parameter_names).tap do |missing_parameters|
+          implementation_parameters.each do |kind, parameter_name|
+            missing_parameters.delete(parameter_name) unless %i[block rest keyrest].include?(kind)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/strict/interfaces/instance.rb
+++ b/lib/strict/interfaces/instance.rb
@@ -5,59 +5,11 @@ module Strict
     module Instance
       attr_reader :implementation
 
-      # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
       def initialize(implementation)
-        missing_methods = nil
-        invalid_method_definitions = Hash.new do |h, k|
-          h[k] = { additional_parameters: [], missing_parameters: [], non_keyword_parameters: [] }
-        end
-
-        self.class.strict_instance_methods.each do |method_name, strict_method| # rubocop:disable Metrics/BlockLength
-          unless implementation.respond_to?(method_name)
-            missing_methods ||= []
-            missing_methods << method_name
-            next
-          end
-
-          expected_parameters = Set.new(strict_method.parameters.map(&:name))
-          defined_parameters = Set.new
-          has_keyword_splat = false
-
-          implementation.method(method_name).parameters.each do |kind, parameter_name|
-            case kind
-            when :block, :rest
-              next
-            when :keyrest
-              has_keyword_splat = true
-              next
-            end
-
-            if expected_parameters.include?(parameter_name)
-              defined_parameters.add(parameter_name)
-              invalid_method_definitions[method_name][:non_keyword_parameters] << parameter_name if kind != :keyreq
-            else
-              invalid_method_definitions[method_name][:additional_parameters] << parameter_name
-            end
-          end
-
-          next if has_keyword_splat
-
-          missing_parameters = expected_parameters - defined_parameters
-          invalid_method_definitions[method_name][:missing_parameters] = missing_parameters if missing_parameters.any?
-        end
-
-        if missing_methods || !invalid_method_definitions.empty?
-          raise Strict::ImplementationDoesNotConformError.new(
-            interface: self.class,
-            receiver: implementation,
-            missing_methods: missing_methods,
-            invalid_method_definitions: invalid_method_definitions
-          )
-        end
+        self.class.strict_interface_conformance.verify!(implementation)
 
         @implementation = implementation
       end
-      # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
     end
   end
 end

--- a/spec/strict/interface_spec.rb
+++ b/spec/strict/interface_spec.rb
@@ -85,6 +85,30 @@ RSpec.describe Strict::Interface do
       }
     end
 
+    it "preserves the conformance error payload" do
+      implementation = InterfaceTest::BadImplementation.new
+
+      expect do
+        InterfaceTest::Interface.new(implementation)
+      end.to raise_error(Strict::ImplementationDoesNotConformError) { |error|
+        expect(error.interface).to be(InterfaceTest::Interface)
+        expect(error.receiver).to be(implementation)
+        expect(error.missing_methods).to eq(%i[third_method no_params])
+        expect(error.invalid_method_definitions).to eq(
+          first_method: {
+            additional_parameters: [:extra],
+            missing_parameters: [],
+            non_keyword_parameters: [:foo]
+          },
+          second_method: {
+            additional_parameters: [],
+            missing_parameters: Set[:bat],
+            non_keyword_parameters: []
+          }
+        )
+      }
+    end
+
     it "does not raise when given a good implementation" do
       interface = InterfaceTest::Interface.new(InterfaceTest::GoodImplementation.new)
 
@@ -124,12 +148,45 @@ RSpec.describe Strict::Interface do
       end.to raise_error(Strict::ImplementationDoesNotConformError)
     end
 
+    it "raises when an explicit keyword parameter is optional" do
+      implementation = Class.new do
+        def call(one:, two: nil); end
+      end.new
+
+      expect do
+        interface_class.new(implementation)
+      end.to raise_error(Strict::ImplementationDoesNotConformError) { |error|
+        expect(error.invalid_method_definitions).to eq(
+          call: {
+            additional_parameters: [],
+            missing_parameters: [],
+            non_keyword_parameters: [:two]
+          }
+        )
+      }
+    end
+
     it "raises when missing a method" do
       expect do
         interface_class.new(
           Class.new.new
         )
       end.to raise_error(Strict::ImplementationDoesNotConformError)
+    end
+
+    it "treats a non-public exposed method as missing" do
+      implementation = Class.new do
+        private
+
+        def call(one:, two:); end
+      end.new
+
+      expect do
+        interface_class.new(implementation)
+      end.to raise_error(Strict::ImplementationDoesNotConformError) { |error|
+        expect(error.missing_methods).to eq([:call])
+        expect(error.invalid_method_definitions).to be_empty
+      }
     end
 
     it "does not raise when other methods are defined" do
@@ -163,6 +220,24 @@ RSpec.describe Strict::Interface do
       end.not_to raise_error
     end
 
+    it "rejects an additional explicit parameter when keywords are splatted" do
+      implementation = Class.new do
+        def call(one:, three:, **kwargs); end
+      end.new
+
+      expect do
+        interface_class.new(implementation)
+      end.to raise_error(Strict::ImplementationDoesNotConformError) { |error|
+        expect(error.invalid_method_definitions).to eq(
+          call: {
+            additional_parameters: [:three],
+            missing_parameters: [],
+            non_keyword_parameters: []
+          }
+        )
+      }
+    end
+
     it "does not raise when non-keyword args are entirely splatted" do
       expect do
         interface_class.new(
@@ -191,6 +266,28 @@ RSpec.describe Strict::Interface do
           end.new
         )
       end.not_to raise_error
+    end
+
+    it "inspects singleton methods again for each receiver wrapping" do
+      implementation = Object.new
+      implementation.define_singleton_method(:call) { |one:, two:| one || two }
+
+      expect { interface_class.new(implementation) }.not_to raise_error
+
+      implementation.define_singleton_method(:call) { |one:| one }
+
+      expect do
+        interface_class.new(implementation)
+      end.to raise_error(Strict::ImplementationDoesNotConformError) { |error|
+        expect(error.receiver).to be(implementation)
+        expect(error.invalid_method_definitions).to eq(
+          call: {
+            additional_parameters: [],
+            missing_parameters: Set[:two],
+            non_keyword_parameters: []
+          }
+        )
+      }
     end
   end
 


### PR DESCRIPTION
## Summary

- compile each exposed method's fixed name and parameter-name array once at `expose` time in one interface-owned conformance checker
- keep receiver conformance dynamic by reflecting the receiver's current public method and parameters on every interface construction; no implementation-class or receiver conformance cache is added
- allocate missing-method and invalid-definition state only after an error is found, while preserving the existing `ImplementationDoesNotConformError` readers and payload shapes
- reduce `Interfaces::Instance#initialize` to validation followed by storing the implementation, removing 49 lines and its four metric suppressions
- characterize checker-produced payloads, public visibility, required explicit keywords, keyword-rest behavior, and repeated singleton-method inspection
- add successful interface construction as an eighth row alongside the existing seven-row benchmark

Interface call forwarding, wrappers, coercion, reserved names, error formatting, attributes/values, declarations, and configuration are unchanged.

## Ancestry

The prior #91–#97 stack is merged. PR #97 was squash-merged to `main` as `9ba1eb679cd032aa99f8380c5739401933d32595`, which is this PR's exact base.

The independent two-commit range is:

1. `f10cc382812f6f5bcee397d7968c104685060626` — Characterize interface conformance construction
2. `5d9a24cbf2a87443d9a4b60b5c24c2494cd2e214` — Compile interface conformance expectations once

The merge-base and the first child's parent are both `9ba1eb679cd032aa99f8380c5739401933d32595`.

## Benchmark

Ruby 3.3.12. Each full run used 100,000 iterations, 20,000 warmup iterations, and 5 timing samples. The table reports the median of three full-run medians per revision. Before is characterization commit `f10cc38`, which contains the benchmark row and tests but not the production change; after is `5d9a24c`.

| Operation | Before ns/op | After ns/op | Change | Before allocations/op | After allocations/op |
| --- | ---: | ---: | ---: | ---: | ---: |
| value initialization | 1873.6 | 2011.6 | +7.4% | 4.000 | 4.000 |
| mutable assignment | 394.5 | 424.3 | +7.6% | 0.000 | 0.000 |
| verified method call | 1968.9 | 1998.3 | +1.5% | 6.000 | 6.000 |
| interface construction | 5056.3 | 1073.3 | -78.8% | 19.000 | 4.000 |
| interface call | 2166.7 | 2329.4 | +7.5% | 8.000 | 8.000 |
| to_h | 847.3 | 846.9 | -0.0% | 2.000 | 2.000 |
| equality | 1475.6 | 1382.1 | -6.3% | 3.000 | 3.000 |
| hashing | 928.8 | 941.1 | +1.3% | 2.000 | 2.000 |

Successful construction is 4.7× as fast and removes 15 allocations per wrapper. All seven existing rows retain their exact allocation counts. Untouched timing rows varied in both directions from -6.3% through +7.6%; interface forwarding is unchanged, and the unrelated value initialization/mutable assignment movement shows the same run-level timing variance.

## Example accounting

- exact base `main`: 226 examples
- characterization commit: 231 examples (+5 focused examples)
- implementation commit: 231 examples (no test-count change)

## Verification

- `bundle exec rake` at `f10cc38`: 231 examples, RuboCop, and RBS passed
- `bundle exec rake` at `5d9a24c`: 231 examples, RuboCop, and RBS passed
- `bundle exec rake benchmark`: three full runs per revision
