### PR TITLE
Fix keyrest precedence and interface parameter matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ run validations. The `sample_rate` is used in tandem with `random` to determine 
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the specs. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
-Run `bundle exec rake benchmark` to measure baseline timing and allocations for value initialization, mutable assignment, verified method calls, interface calls, `to_h`, equality, and hashing. Set `ITERATIONS`, `WARMUP_ITERATIONS`, or `SAMPLES` to change the workload, and set `FORMAT=markdown` to produce a Markdown table. Pull requests publish this table in a non-blocking job summary and upload it as an artifact. These benchmarks report measurements only and do not enforce thresholds.
+Run `bundle exec rake benchmark` to measure baseline timing and allocations for value initialization, mutable assignment, verified method calls, interface construction, interface calls, `to_h`, equality, and hashing. Set `ITERATIONS`, `WARMUP_ITERATIONS`, or `SAMPLES` to change the workload, and set `FORMAT=markdown` to produce a Markdown table. Pull requests publish this table in a non-blocking job summary and upload it as an artifact. These benchmarks report measurements only and do not enforce thresholds.
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and the created tag, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 

--- a/lib/strict/interfaces/conformance.rb
+++ b/lib/strict/interfaces/conformance.rb
@@ -13,7 +13,8 @@ module Strict
 
         method_expectations << MethodExpectation.new(
           name: verifiable_method.name,
-          parameter_names: parameter_names
+          parameter_names: parameter_names,
+          expected_parameter_mask: (1 << parameter_names.length) - 1
         )
       end
 
@@ -32,7 +33,7 @@ module Strict
 
       private
 
-      MethodExpectation = Data.define(:name, :parameter_names)
+      MethodExpectation = Data.define(:name, :parameter_names, :expected_parameter_mask)
       private_constant :MethodExpectation
 
       attr_reader :interface, :method_expectations
@@ -63,7 +64,7 @@ module Strict
 
       # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
       def invalid_definition_for(expectation, implementation_parameters)
-        defined_parameter_count = 0
+        matched_parameter_mask = 0
         has_keyword_splat = false
         additional_parameters = nil
         non_keyword_parameters = nil
@@ -77,22 +78,17 @@ module Strict
             next
           end
 
-          unless expectation.parameter_names.include?(parameter_name)
+          parameter_index = expectation.parameter_names.index(parameter_name)
+          unless parameter_index
             (additional_parameters ||= []) << parameter_name
             next
           end
 
-          defined_parameter_count += 1
+          matched_parameter_mask |= 1 << parameter_index
           (non_keyword_parameters ||= []) << parameter_name unless kind == :keyreq
         end
 
-        unless has_keyword_splat
-          missing_parameters = missing_parameters_from(
-            expectation,
-            implementation_parameters,
-            defined_parameter_count
-          )
-        end
+        missing_parameters = missing_parameters_from(expectation, matched_parameter_mask) unless has_keyword_splat
         return unless missing_parameters || additional_parameters || non_keyword_parameters
 
         {
@@ -103,12 +99,12 @@ module Strict
       end
       # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
 
-      def missing_parameters_from(expectation, implementation_parameters, defined_parameter_count)
-        return if defined_parameter_count == expectation.parameter_names.length
+      def missing_parameters_from(expectation, matched_parameter_mask)
+        return if matched_parameter_mask == expectation.expected_parameter_mask
 
-        Set.new(expectation.parameter_names).tap do |missing_parameters|
-          implementation_parameters.each do |kind, parameter_name|
-            missing_parameters.delete(parameter_name) unless %i[block rest keyrest].include?(kind)
+        Set.new.tap do |missing_parameters|
+          expectation.parameter_names.each_with_index do |parameter_name, index|
+            missing_parameters << parameter_name if matched_parameter_mask.nobits?(1 << index)
           end
         end
       end

--- a/lib/strict/methods/verifiable_method.rb
+++ b/lib/strict/methods/verifiable_method.rb
@@ -277,9 +277,11 @@ module Strict
         return value if keyword_parameter_names.empty? && !value.equal?(kwargs)
         return verified_kwargs if keyword_parameter_names.empty?
 
-        (verified_kwargs || kwargs.dup).delete_if do |name, _value|
+        merged_kwargs = verified_kwargs || kwargs.dup
+        merged_kwargs.delete_if do |name, _value|
           !keyword_parameter_names.include?(name)
-        end.merge!(value)
+        end
+        merged_kwargs.merge!(value) { |_name, explicit_value, _keyrest_value| explicit_value }
       end
 
       def no_additional_keywords?(kwargs)

--- a/spec/strict/interface_spec.rb
+++ b/spec/strict/interface_spec.rb
@@ -73,6 +73,18 @@ RSpec.describe Strict::Interface do
     end
   end
 
+  let(:underscore_interface_class) do
+    Class.new do
+      include Strict::Interface
+
+      expose(:call) do
+        _a String
+        _b String
+        returns String
+      end
+    end
+  end
+
   describe ".new" do
     it "raises when given a bad implementation" do
       expect do
@@ -127,6 +139,36 @@ RSpec.describe Strict::Interface do
         )
       end.to raise_error(Strict::ImplementationDoesNotConformError)
     end
+
+    # rubocop:disable Naming/MethodParameterName
+    it "rejects duplicate keyword names that omit an expected parameter" do
+      implementation = Class.new do
+        def call(_a:, _a:); end
+      end.new
+
+      expect do
+        underscore_interface_class.new(implementation)
+      end.to raise_error(Strict::ImplementationDoesNotConformError)
+    end
+
+    it "reports the expected parameter omitted by duplicate keyword names" do
+      implementation = Class.new do
+        def call(_a:, _a:, extra:); end
+      end.new
+
+      expect do
+        underscore_interface_class.new(implementation)
+      end.to raise_error(Strict::ImplementationDoesNotConformError) { |error|
+        expect(error.invalid_method_definitions).to eq(
+          call: {
+            additional_parameters: [:extra],
+            missing_parameters: Set[:_b],
+            non_keyword_parameters: []
+          }
+        )
+      }
+    end
+    # rubocop:enable Naming/MethodParameterName
 
     it "raises when given an extra parameter" do
       expect do

--- a/spec/strict/method_spec.rb
+++ b/spec/strict/method_spec.rb
@@ -36,6 +36,47 @@ RSpec.describe Strict::Method do
     expect(instance.call(1, 2, 3, two: 2.2, other: 1)).to eq([1, [2, 3], 2.2, { other: 1 }])
   end
 
+  it "keeps an explicit keyword when keyrest coercion creates the same name" do
+    instance = Class.new do
+      include Strict::Method
+
+      sig do
+        value Integer, coerce: ->(argument) { argument.to_i }
+        options Hash, coerce: ToHash(with_keys: ->(key) { key.to_sym })
+        returns Array
+      end
+      def call(value:, **options) = [value, options]
+    end.new
+
+    result = instance.call(value: "1", **{ "value" => "unvalidated", "other" => 2 })
+
+    expect(result).to eq([1, { other: 2 }])
+  end
+
+  it "keeps explicit keywords when a keyrest validator adds the same names" do
+    validator = Object.new
+    validator.define_singleton_method(:===) do |options|
+      options[:value] = "unvalidated"
+      options[:fallback] = "unvalidated"
+      true
+    end
+    instance = Class.new do
+      include Strict::Method
+
+      sig do
+        value Integer
+        fallback Integer, default: 2
+        options validator
+        returns Array
+      end
+      def call(value:, fallback:, **options) = [value, fallback, options]
+    end.new
+
+    result = instance.call(value: 1, untouched: true)
+
+    expect(result).to eq([1, 2, { untouched: true }])
+  end
+
   it "forwards cardinality changes from an in-place rest coercion" do
     replacements = [[9], [9, 10, 11]]
     coercer = ->(values) { values.replace(replacements.shift) }


### PR DESCRIPTION
## Summary

- Keep validated, coerced, or defaulted explicit keywords when transformed `**keyrest` creates the same symbol name.
- Track distinct interface parameter matches with a compiled bitmask so duplicate reflected names cannot cover an omitted expected keyword.
- Add `interface construction` to the README benchmark workload list.

## Root causes

`VerifiableMethod` removed original keyrest entries, then merged transformed keyrest after explicit keywords. Hash collisions therefore selected the transformed, unvalidated keyrest value. The merge now resolves collisions in favor of the already validated explicit value while preserving other transformed keyrest entries.

`Interfaces::Conformance` counted every matching reflection entry. Ruby can report duplicate underscore keyword names, so two `_a:` entries could equal the expected `_a:`/`_b:` count. Conformance now sets one bit per expected name and only builds the public missing-parameter `Set` on failure.

## Red/green evidence

Before the fixes, the keyrest regressions received `"unvalidated"` instead of the coerced explicit value and generated default. The duplicate-name regressions either accepted an implementation with no `_b:` or returned `missing_parameters: []` instead of `Set[:_b]`.

After the fixes:

- `bundle exec rspec spec/strict/method_spec.rb spec/strict/strict_public_api_spec.rb`: 44 examples, 0 failures
- `bundle exec rspec spec/strict/interface_spec.rb spec/strict/implementation_does_not_conform_error_spec.rb spec/strict/strict_public_api_spec.rb`: 53 examples, 0 failures
- `bundle exec rake`: 235 examples, 0 failures; 80 RuboCop files, no offenses; RBS valid

## Benchmark

Ruby 3.3.12; 100,000 iterations; 20,000 warmup iterations; median of 5 timing samples.

| Operation | Before ns/op | After ns/op | Before alloc/op | After alloc/op |
| --- | ---: | ---: | ---: | ---: |
| value initialization | 1985.7 | 1892.0 | 4.000 | 4.000 |
| mutable assignment | 422.7 | 403.7 | 0.000 | 0.000 |
| verified method call | 2011.2 | 1948.5 | 6.000 | 6.000 |
| interface construction | 1165.1 | 1112.3 | 4.000 | 4.000 |
| interface call | 3202.9 | 2317.9 | 8.000 | 8.000 |
| `to_h` | 1214.4 | 817.5 | 2.000 | 2.000 |
| equality | 1811.4 | 1745.0 | 3.000 | 3.000 |
| hashing | 1406.0 | 939.1 | 2.000 | 2.000 |

Allocations are unchanged in all eight rows. Timing changed across unrelated operations in the same direction, so the timing differences are treated as noisy environment variation, not as measured improvements.

## Base

Exact `origin/main`: `39c2c6d318978600c375e0f845b6625a633693e5`
