### PR TITLE
Document next-major API and benchmark gains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,42 @@
 ## [Unreleased]
 
+### Added
+
+- Define and characterize the supported next-major API in `API.md`, provide RBS signatures for that boundary, validate them in the default checks, and add repeatable timing and allocation benchmark tooling.
+
+### Breaking changes
+
+- Standardize all four capabilities on `include`: `Strict::Value`, `Strict::Object`, `Strict::Method`, and `Strict::Interface`. The legacy `extend Strict::Method` and `extend Strict::Interface` forms are outside the supported next-major API.
+
 ### Changed
 
 - Require Ruby 3.3 or newer and test against all maintained Ruby releases.
 - Update runtime and development dependencies to their latest release lines.
+- Compile signed-method invocation metadata once, reuse unchanged call arguments, and consolidate generated wrappers by owner.
+- Preserve validated explicit keywords when keyrest processing changes a signed call.
+- Forward validated interface calls directly to implementations and compile interface-conformance expectations once per interface definition.
+- Require interface implementations to cover every distinct exposed keyword parameter.
+- Reduce value and object hot-path allocations during initialization, `to_h`, equality, and hashing.
+- Share declaration invariants between attributes and parameters, with isolated backing storage for every distinct attribute name.
+- Keep Strict configuration overrides in isolated internal thread-local storage to avoid collisions with application keys.
+- Generate attribute readers and writers through one shared implementation, with mutable writers bound directly to their declarations.
+
+### Performance
+
+Representative microbenchmarks compared `90ba08a` (before) with `dff84b2` (after) on Ruby 3.3.12, with YJIT disabled. Both revisions used the same pinned harness and public workloads. Results are the median of six interleaved process-run medians; each run used 50,000 warmup iterations, 200,000 measured iterations, and nine timing samples. Allocation counts were stable across all six runs.
+
+| Operation | `90ba08a` ns/op | `dff84b2` ns/op | Change | Allocations/op |
+| --- | ---: | ---: | ---: | ---: |
+| Value initialization | 4,537 | 2,017 | -56% | 11 → 4 |
+| Mutable assignment | 477 | 415 | -13% | 0 → 0 |
+| Verified method call | 2,384 | 1,996 | -16% | 10 → 6 |
+| Interface construction | 5,582 | 1,283 | -77% | 19 → 4 |
+| Interface call | 3,535 | 2,425 | -31% | 16 → 8 |
+| `to_h` | 1,468 | 902 | -39% | 6 → 2 |
+| Equality | 2,982 | 1,512 | -49% | 12 → 3 |
+| Hashing | 2,010 | 940 | -53% | 6 → 2 |
+
+The equal-weight geometric mean of the eight after/before timing ratios is 0.54, or 46% lower. These microbenchmarks are environment-dependent measurements, not performance guarantees.
 
 ## [0.0.0] - 2022-10-01
 


### PR DESCRIPTION
## Summary

- document the next-major compatibility boundary and the breaking standardization on `include`
- summarize the landed implementation, correctness, and performance work through PR #99
- publish a fixed-harness comparison of all eight landed, comparable public hot paths

## Benchmark methodology

- BEFORE: `90ba08afa9b0116fe6759650aa051eea21ef439b`
- AFTER: `dff84b2be321fae7b2a7fe6d8d02da71310dc98b`
- Ruby: `ruby 3.3.12 (2026-07-16 revision 0581089df9) [x86_64-linux]`; YJIT disabled
- Environment: separate clean detached worktrees in the same Amp orb
- Harness: the AFTER revision's pinned `benchmark/baseline.rb` for both revisions
- Settings: 200,000 iterations, 50,000 warmup iterations, nine timing samples, six independent processes per revision
- Process order: BEFORE/AFTER, AFTER/BEFORE, BEFORE/AFTER, AFTER/BEFORE, BEFORE/AFTER, AFTER/BEFORE
- Reduction: median of the six per-process timing medians; allocations/op were identical in all six processes for each revision

Before measuring, a separate public-API sanity check exercised every operation and verified its expected return value and resulting state at both exact revisions.

Each process used one of these commands:

```sh
ITERATIONS=200000 WARMUP_ITERATIONS=50000 SAMPLES=9 FORMAT=text bundle exec ruby -I/tmp/strict-benchmark-rebase-01a01fa1/before/lib /tmp/strict-benchmark-rebase-01a01fa1/after/benchmark/baseline.rb
ITERATIONS=200000 WARMUP_ITERATIONS=50000 SAMPLES=9 FORMAT=text bundle exec ruby -I/tmp/strict-benchmark-rebase-01a01fa1/after/lib /tmp/strict-benchmark-rebase-01a01fa1/after/benchmark/baseline.rb
```

## Results

| Operation | BEFORE ns/op | AFTER ns/op | Change | Allocations/op |
| --- | ---: | ---: | ---: | ---: |
| Value initialization | 4,537 | 2,017 | -56% | 11 → 4 |
| Mutable assignment | 477 | 415 | -13% | 0 → 0 |
| Verified method call | 2,384 | 1,996 | -16% | 10 → 6 |
| Interface construction | 5,582 | 1,283 | -77% | 19 → 4 |
| Interface call | 3,535 | 2,425 | -31% | 16 → 8 |
| `to_h` | 1,468 | 902 | -39% | 6 → 2 |
| Equality | 2,982 | 1,512 | -49% | 12 → 3 |
| Hashing | 2,010 | 940 | -53% | 6 → 2 |

The equal-weight geometric mean of the eight AFTER/BEFORE timing ratios is 0.54, or 46% lower. Timing is environment-dependent; these representative microbenchmarks are not guarantees. Allocation changes were stable across all runs.

## Verification

- `bundle exec rake` — 235 examples, 0 failures; 80 files inspected with no RuboCop offenses; RBS validation passed
- `bundle exec rake benchmark` — smoke check passed for all eight operations
- the changelog table and aggregate were recalculated from all 12 saved raw process outputs
- GitHub reports commit `a17da8332e44a5cde28b37474dbf2dfb605f3eed` as cryptographically signed and verified
