### PR TITLE
Add discriminated union value objects

### DIFF
--- a/API.md
+++ b/API.md
@@ -82,19 +82,27 @@ class PaymentResult
   discriminator :status
 
   variant :authorized do
-    authorization_id String
-    amount_in_cents Integer
+    attributes do
+      authorization_id String
+      amount_in_cents Integer
+    end
+
+    def successful? = true
   end
 
   variant :declined do
-    reason String
+    attributes do
+      reason String
+    end
+
+    def successful? = false
   end
 end
 ```
 
 There is no default discriminator. A variant name must be a lower snake-case string or symbol. Its canonical tag is the corresponding symbol, and Strict generates a PascalCase nested subclass. For example, `variant :requires_action` generates `PaymentResult::RequiresAction < PaymentResult` with the tag `:requires_action`.
 
-Each generated variant includes `Strict::Value`. Its declaration block uses the attribute DSL, and its implicit first attribute is the discriminator with a fixed default value:
+The variant block configures the generated subclass. It can include modules, define methods, and contain zero or one `attributes` block. Strict combines that block with an implicit first attribute containing the discriminator's fixed default value:
 
 ```ruby
 PaymentResult::Authorized.new(
@@ -124,7 +132,7 @@ payment_result PaymentResult
 coerced_payment_result PaymentResult, coerce: PaymentResult.coercer
 ```
 
-Declaring a discriminator more than once, declaring a duplicate tag, using an invalid variant name, or replacing an existing generated constant raises `ArgumentError`. Declaration return values, generated-class reflection details, and the exact text of declaration and coercion errors are outside the compatibility boundary.
+Declaring a discriminator more than once, declaring a duplicate tag, using an invalid variant name, replacing an existing generated constant, declaring multiple attribute blocks, or redeclaring the discriminator raises `ArgumentError`. Declaration return values, generated-class reflection details, and the exact text of declaration and coercion errors are outside the compatibility boundary.
 
 ### Signed methods
 

--- a/API.md
+++ b/API.md
@@ -117,6 +117,13 @@ The union class `coercer`:
 - dispatches hash-like input through the selected variant's value coercer;
 - raises `ArgumentError` when the discriminator is missing or unknown.
 
+A union class can be an attribute or method validator. Add its coercer when the declaration must also accept hash-like input:
+
+```ruby
+payment_result PaymentResult
+coerced_payment_result PaymentResult, coerce: PaymentResult.coercer
+```
+
 Declaring a discriminator more than once, declaring a duplicate tag, using an invalid variant name, or replacing an existing generated constant raises `ArgumentError`. Declaration return values, generated-class reflection details, and the exact text of declaration and coercion errors are outside the compatibility boundary.
 
 ### Signed methods

--- a/API.md
+++ b/API.md
@@ -11,6 +11,7 @@ include Strict::Value
 include Strict::Object
 include Strict::Method
 include Strict::Interface
+include Strict::Union
 ```
 
 The former `extend Strict::Method` and `extend Strict::Interface` forms are not part of this major-version API.
@@ -35,6 +36,7 @@ Both capabilities provide:
 `Strict::Value` does not provide writers. It provides:
 
 - `with(**attributes)`, which returns a validated instance of the same class;
+- `deconstruct_keys(keys)`, for Ruby hash and class patterns;
 - `==` and `eql?`, based on exact class and attribute values;
 - `hash`, consistent with `eql?`.
 
@@ -68,6 +70,54 @@ Only one default option can be present on one declaration.
 - `true`, which calls the class method `coerce_<attribute>`.
 
 The generated class `coercer` returns `nil` and non-hash-like values unchanged. For hash-like input, it recognizes declared symbol or string keys and initializes the class with those values.
+
+### Discriminated unions
+
+`Strict::Union` defines a closed, discriminated union of generated value-object variants. A union must declare one discriminator before it declares variants:
+
+```ruby
+class PaymentResult
+  include Strict::Union
+
+  discriminator :status
+
+  variant :authorized do
+    authorization_id String
+    amount_in_cents Integer
+  end
+
+  variant :declined do
+    reason String
+  end
+end
+```
+
+There is no default discriminator. A variant name must be a lower snake-case string or symbol. Its canonical tag is the corresponding symbol, and Strict generates a PascalCase nested subclass. For example, `variant :requires_action` generates `PaymentResult::RequiresAction < PaymentResult` with the tag `:requires_action`.
+
+Each generated variant includes `Strict::Value`. Its declaration block uses the attribute DSL, and its implicit first attribute is the discriminator with a fixed default value:
+
+```ruby
+PaymentResult::Authorized.new(
+  authorization_id: "auth_123",
+  amount_in_cents: 1_000
+).to_h
+# => { status: :authorized, authorization_id: "auth_123", amount_in_cents: 1_000 }
+```
+
+Variants therefore use the documented `Strict::Value` behavior for initialization, validation, coercion, defaults, copying, equality, hashing, conversion, inspection, and pattern matching. A variant declaration cannot redeclare the discriminator. The union base cannot be instantiated directly.
+
+`PaymentResult === value` is true only when `value` has the exact class of a registered variant. Generated variant classes retain normal Ruby class matching, including matching instances of their subclasses. Union and variant inheritance are outside the compatibility boundary.
+
+The union class `coercer`:
+
+- returns `nil` and non-hash-like values unchanged;
+- returns an existing exact union member unchanged;
+- accepts the discriminator as a symbol or string key;
+- accepts a registered tag as its symbol or string value;
+- dispatches hash-like input through the selected variant's value coercer;
+- raises `ArgumentError` when the discriminator is missing or unknown.
+
+Declaring a discriminator more than once, declaring a duplicate tag, using an invalid variant name, or replacing an existing generated constant raises `ArgumentError`. Declaration return values, generated-class reflection details, and the exact text of declaration and coercion errors are outside the compatibility boundary.
 
 ### Signed methods
 
@@ -167,4 +217,4 @@ Readers that expose attribute, parameter, or method descriptors are internal.
 
 `Strict::VERSION` is public. `Strict::ISSUE_TRACKER` is internal.
 
-`Strict::Attribute`, `Strict::Parameter`, `Strict::Return`, `strict_class_methods`, and `strict_instance_methods` are internal. The `Strict::Accessor`, `Strict::Reader`, `Strict::Attributes`, `Strict::Dsl`, `Strict::Interfaces`, and `Strict::Methods` namespaces and their contents are also internal.
+`Strict::Attribute`, `Strict::Parameter`, `Strict::Return`, `strict_class_methods`, and `strict_instance_methods` are internal. The `Strict::Accessor`, `Strict::Reader`, `Strict::Attributes`, `Strict::Dsl`, `Strict::Interfaces`, `Strict::Methods`, and `Strict::Unions` namespaces and their contents are also internal.

--- a/API.md
+++ b/API.md
@@ -81,7 +81,7 @@ class PaymentResult
 
   discriminator :status
 
-  variant :authorized do
+  variant :authorized, tag: "payment.authorized" do
     attributes do
       authorization_id String
       amount_in_cents Integer
@@ -100,7 +100,7 @@ class PaymentResult
 end
 ```
 
-There is no default discriminator. A variant name must be a lower snake-case string or symbol. Its canonical tag is the corresponding symbol, and Strict generates a PascalCase nested subclass. For example, `variant :requires_action` generates `PaymentResult::RequiresAction < PaymentResult` with the tag `:requires_action`.
+There is no default discriminator. A variant name must be a lower snake-case string or symbol, and Strict generates its PascalCase nested subclass. By default, the discriminator tag is the name's corresponding symbol. The optional `tag:` can assign a different string or symbol. For example, `variant :requires_action, tag: "action-required"` generates `PaymentResult::RequiresAction < PaymentResult` with the tag `"action-required"`.
 
 The variant block configures the generated subclass. It can include modules, define methods, and contain zero or one `attributes` block. Strict combines that block with an implicit first attribute containing the discriminator's fixed default value:
 
@@ -109,7 +109,7 @@ PaymentResult::Authorized.new(
   authorization_id: "auth_123",
   amount_in_cents: 1_000
 ).to_h
-# => { status: :authorized, authorization_id: "auth_123", amount_in_cents: 1_000 }
+# => { status: "payment.authorized", authorization_id: "auth_123", amount_in_cents: 1_000 }
 ```
 
 Variants therefore use the documented `Strict::Value` behavior for initialization, validation, coercion, defaults, copying, equality, hashing, conversion, inspection, and pattern matching. A variant declaration cannot redeclare the discriminator. The union base cannot be instantiated directly.
@@ -121,7 +121,7 @@ The union class `coercer`:
 - returns `nil` and non-hash-like values unchanged;
 - returns an existing exact union member unchanged;
 - accepts the discriminator as a symbol or string key;
-- accepts a registered tag as its symbol or string value;
+- accepts a registered tag as its equivalent symbol or string value and stores its configured form;
 - dispatches hash-like input through the selected variant's value coercer;
 - raises `ArgumentError` when the discriminator is missing or unknown.
 
@@ -132,7 +132,7 @@ payment_result PaymentResult
 coerced_payment_result PaymentResult, coerce: PaymentResult.coercer
 ```
 
-Declaring a discriminator more than once, declaring a duplicate tag, using an invalid variant name, replacing an existing generated constant, declaring multiple attribute blocks, or redeclaring the discriminator raises `ArgumentError`. Declaration return values, generated-class reflection details, and the exact text of declaration and coercion errors are outside the compatibility boundary.
+Declaring a discriminator more than once, declaring equivalent duplicate string or symbol tags, using an invalid variant name or tag, replacing an existing generated constant, declaring multiple attribute blocks, or redeclaring the discriminator raises `ArgumentError`. Declaration return values, generated-class reflection details, and the exact text of declaration and coercion errors are outside the compatibility boundary.
 
 ### Signed methods
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Added
 
 - Define and characterize the supported next-major API in `API.md`, provide RBS signatures for that boundary, validate them in the default checks, and add repeatable timing and allocation benchmark tooling.
+- Add closed discriminated unions whose generated variants use `Strict::Value` for attributes and value behavior.
 
 ### Breaking changes
 

--- a/README.md
+++ b/README.md
@@ -62,12 +62,20 @@ class PaymentResult
   discriminator :status
 
   variant :authorized do
-    authorization_id String
-    amount_in_cents Integer
+    attributes do
+      authorization_id String
+      amount_in_cents Integer
+    end
+
+    def successful? = true
   end
 
   variant :declined do
-    reason String
+    attributes do
+      reason String
+    end
+
+    def successful? = false
   end
 end
 
@@ -77,6 +85,9 @@ authorized = PaymentResult::Authorized.new(
 )
 authorized.to_h
 # => { status: :authorized, authorization_id: "auth_123", amount_in_cents: 1_000 }
+
+authorized.successful?
+# => true
 
 result = PaymentResult.coercer.call(
   "status" => "declined",

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ class PaymentResult
 
   discriminator :status
 
-  variant :authorized do
+  variant :authorized, tag: "payment.authorized" do
     attributes do
       authorization_id String
       amount_in_cents Integer
@@ -84,7 +84,7 @@ authorized = PaymentResult::Authorized.new(
   amount_in_cents: 1_000
 )
 authorized.to_h
-# => { status: :authorized, authorization_id: "auth_123", amount_in_cents: 1_000 }
+# => { status: "payment.authorized", authorization_id: "auth_123", amount_in_cents: 1_000 }
 
 authorized.successful?
 # => true

--- a/README.md
+++ b/README.md
@@ -53,6 +53,46 @@ Money.new(amount_in_cents: 100_00) == Money.new(amount_in_cents: 100_00)
 # => true
 ```
 
+### `Strict::Union`
+
+```rb
+class PaymentResult
+  include Strict::Union
+
+  discriminator :status
+
+  variant :authorized do
+    authorization_id String
+    amount_in_cents Integer
+  end
+
+  variant :declined do
+    reason String
+  end
+end
+
+authorized = PaymentResult::Authorized.new(
+  authorization_id: "auth_123",
+  amount_in_cents: 1_000
+)
+authorized.to_h
+# => { status: :authorized, authorization_id: "auth_123", amount_in_cents: 1_000 }
+
+result = PaymentResult.coercer.call(
+  "status" => "declined",
+  "reason" => "insufficient_funds"
+)
+# => #<PaymentResult::Declined status=:declined reason="insufficient_funds">
+
+case result
+in PaymentResult::Authorized(authorization_id:)
+  authorization_id
+in PaymentResult::Declined(reason:)
+  reason
+end
+# => "insufficient_funds"
+```
+
 ### `Strict::Object`
 
 ```rb

--- a/lib/strict/union.rb
+++ b/lib/strict/union.rb
@@ -56,8 +56,9 @@ module Strict
       def strict_union_build_variant(discriminator, tag, definition)
         variant_class = Class.new(self)
         variant_class.include(Strict::Value)
+        discriminator_coercer = strict_union_discriminator_coercer(discriminator, tag)
         variant_class.attributes do
-          strict_attribute discriminator, tag, default_value: tag
+          strict_attribute discriminator, tag, default_value: tag, coerce: discriminator_coercer
           discriminator_attribute = __strict_dsl_internal_attributes.fetch(discriminator)
           instance_exec(&definition)
           unless __strict_dsl_internal_attributes.fetch(discriminator).equal?(discriminator_attribute)
@@ -68,6 +69,17 @@ module Strict
         variant_class
       end
       # rubocop:enable Metrics/MethodLength
+
+      def strict_union_discriminator_coercer(discriminator, tag)
+        lambda do |value|
+          canonical_value = value.is_a?(::String) ? value.to_sym : value
+          unless canonical_value.eql?(tag)
+            raise ArgumentError, "discriminator #{discriminator.inspect} must equal #{tag.inspect}"
+          end
+
+          tag
+        end
+      end
 
       def strict_union_constant_name(tag)
         name = tag.to_s

--- a/lib/strict/union.rb
+++ b/lib/strict/union.rb
@@ -4,11 +4,14 @@ module Strict
   module Union
     VARIANT_NAME = /\A[a-z][a-z0-9]*(?:_[a-z0-9]+)*\z/
     private_constant :VARIANT_NAME
+    Variant = Data.define(:tag, :variant_class)
+    private_constant :Variant
 
     def self.included(union_class)
       union_class.extend(ClassMethods)
       union_class.include(Instance)
       union_class.instance_variable_set(:@strict_union_discriminator, nil)
+      union_class.instance_variable_set(:@strict_union_variant_names, {})
       union_class.instance_variable_set(:@strict_union_variants, {})
     end
 
@@ -20,18 +23,13 @@ module Strict
         nil
       end
 
-      def variant(name, &definition)
+      def variant(name, tag: name.to_sym, &definition)
         discriminator = strict_union_discriminator!
-        tag = name.to_sym
-        constant_name = strict_union_constant_name(tag)
-        raise ArgumentError, "variant #{tag.inspect} already declared for #{self}" if @strict_union_variants.key?(tag)
-        raise ArgumentError, "constant #{constant_name} is already defined for #{self}" if
-          const_defined?(constant_name, false)
-
-        variant_class = strict_union_build_variant(discriminator, tag, definition || -> {})
-        const_set(constant_name, variant_class)
-        @strict_union_variants[tag] = variant_class
-        variant_class
+        name = name.to_sym
+        tag_key = strict_union_tag_key(tag)
+        constant_name = strict_union_validate_variant!(name, tag, tag_key)
+        variant_class = strict_union_build_variant(discriminator, name, tag, definition)
+        strict_union_register_variant(name, tag, tag_key, constant_name, variant_class)
       end
 
       def coercer
@@ -42,19 +40,37 @@ module Strict
       end
 
       def ===(value)
-        @strict_union_variants&.value?(value.class) || false
+        @strict_union_variant_names&.value?(value.class) || false
       end
 
       private
+
+      def strict_union_validate_variant!(name, tag, tag_key)
+        constant_name = strict_union_constant_name(name)
+        raise ArgumentError, "variant #{name.inspect} already declared for #{self}" if
+          @strict_union_variant_names.key?(name)
+        raise ArgumentError, "tag #{tag.inspect} already declared for #{self}" if @strict_union_variants.key?(tag_key)
+        raise ArgumentError, "constant #{constant_name} is already defined for #{self}" if
+          const_defined?(constant_name, false)
+
+        constant_name
+      end
+
+      def strict_union_register_variant(name, tag, tag_key, constant_name, variant_class)
+        const_set(constant_name, variant_class)
+        @strict_union_variant_names[name] = variant_class
+        @strict_union_variants[tag_key] = Variant.new(tag:, variant_class:)
+        variant_class
+      end
 
       def strict_union_discriminator!
         @strict_union_discriminator ||
           raise(ArgumentError, "declare a discriminator before variants for #{self}")
       end
 
-      def strict_union_build_variant(discriminator, tag, definition)
+      def strict_union_build_variant(discriminator, name, tag, definition)
         variant_class = Class.new(self)
-        attribute_definition = strict_union_evaluate_variant(variant_class, tag, definition)
+        attribute_definition = strict_union_evaluate_variant(variant_class, name, definition)
         variant_class.include(Strict::Value)
         strict_union_define_variant_attributes(variant_class, discriminator, tag, attribute_definition)
         variant_class.define_singleton_method(:===, ::Module.instance_method(:===))
@@ -89,14 +105,22 @@ module Strict
       end
 
       def strict_union_discriminator_coercer(discriminator, tag)
+        tag_key = strict_union_tag_key(tag)
         lambda do |value|
-          canonical_value = value.is_a?(::String) ? value.to_sym : value
-          unless canonical_value.eql?(tag)
+          unless strict_union_tag_key(value).eql?(tag_key)
             raise ArgumentError, "discriminator #{discriminator.inspect} must equal #{tag.inspect}"
           end
 
           tag
         end
+      end
+
+      def strict_union_tag_key(tag)
+        unless tag.is_a?(::String) || tag.is_a?(::Symbol)
+          raise ArgumentError, "variant tag must be a String or Symbol, got #{tag.inspect}"
+        end
+
+        tag.is_a?(::String) ? tag.to_sym : tag
       end
 
       def strict_union_constant_name(tag)

--- a/lib/strict/union.rb
+++ b/lib/strict/union.rb
@@ -52,23 +52,41 @@ module Strict
           raise(ArgumentError, "declare a discriminator before variants for #{self}")
       end
 
-      # rubocop:disable Metrics/MethodLength
       def strict_union_build_variant(discriminator, tag, definition)
         variant_class = Class.new(self)
+        attribute_definition = strict_union_evaluate_variant(variant_class, tag, definition)
         variant_class.include(Strict::Value)
+        strict_union_define_variant_attributes(variant_class, discriminator, tag, attribute_definition)
+        variant_class.define_singleton_method(:===, ::Module.instance_method(:===))
+        variant_class
+      end
+
+      def strict_union_evaluate_variant(variant_class, tag, definition)
+        return unless definition
+
+        attribute_definition = nil
+        variant_class.define_singleton_method(:attributes) do |&block|
+          raise ArgumentError, "attributes already declared for variant #{tag.inspect}" if attribute_definition
+
+          attribute_definition = block || -> {}
+          nil
+        end
+        variant_class.class_exec(&definition)
+        variant_class.singleton_class.remove_method(:attributes)
+        attribute_definition
+      end
+
+      def strict_union_define_variant_attributes(variant_class, discriminator, tag, attribute_definition)
         discriminator_coercer = strict_union_discriminator_coercer(discriminator, tag)
         variant_class.attributes do
           strict_attribute discriminator, tag, default_value: tag, coerce: discriminator_coercer
           discriminator_attribute = __strict_dsl_internal_attributes.fetch(discriminator)
-          instance_exec(&definition)
+          instance_exec(&attribute_definition) if attribute_definition
           unless __strict_dsl_internal_attributes.fetch(discriminator).equal?(discriminator_attribute)
             ::Kernel.raise ::ArgumentError, "variants cannot redeclare discriminator #{discriminator.inspect}"
           end
         end
-        variant_class.define_singleton_method(:===, ::Module.instance_method(:===))
-        variant_class
       end
-      # rubocop:enable Metrics/MethodLength
 
       def strict_union_discriminator_coercer(discriminator, tag)
         lambda do |value|

--- a/lib/strict/union.rb
+++ b/lib/strict/union.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+module Strict
+  module Union
+    VARIANT_NAME = /\A[a-z][a-z0-9]*(?:_[a-z0-9]+)*\z/
+    private_constant :VARIANT_NAME
+
+    def self.included(union_class)
+      union_class.extend(ClassMethods)
+      union_class.include(Instance)
+      union_class.instance_variable_set(:@strict_union_discriminator, nil)
+      union_class.instance_variable_set(:@strict_union_variants, {})
+    end
+
+    module ClassMethods
+      def discriminator(name)
+        raise ArgumentError, "discriminator already declared for #{self}" if @strict_union_discriminator
+
+        @strict_union_discriminator = name.to_sym
+        nil
+      end
+
+      def variant(name, &definition)
+        discriminator = strict_union_discriminator!
+        tag = name.to_sym
+        constant_name = strict_union_constant_name(tag)
+        raise ArgumentError, "variant #{tag.inspect} already declared for #{self}" if @strict_union_variants.key?(tag)
+        raise ArgumentError, "constant #{constant_name} is already defined for #{self}" if
+          const_defined?(constant_name, false)
+
+        variant_class = strict_union_build_variant(discriminator, tag, definition || -> {})
+        const_set(constant_name, variant_class)
+        @strict_union_variants[tag] = variant_class
+        variant_class
+      end
+
+      def coercer
+        discriminator = @strict_union_discriminator
+        raise ArgumentError, "declare a discriminator before using the coercer for #{self}" unless discriminator
+
+        Unions::Coercer.new(self, discriminator:, variants: @strict_union_variants)
+      end
+
+      def ===(value)
+        @strict_union_variants&.value?(value.class) || false
+      end
+
+      private
+
+      def strict_union_discriminator!
+        @strict_union_discriminator ||
+          raise(ArgumentError, "declare a discriminator before variants for #{self}")
+      end
+
+      # rubocop:disable Metrics/MethodLength
+      def strict_union_build_variant(discriminator, tag, definition)
+        variant_class = Class.new(self)
+        variant_class.include(Strict::Value)
+        variant_class.attributes do
+          strict_attribute discriminator, tag, default_value: tag
+          discriminator_attribute = __strict_dsl_internal_attributes.fetch(discriminator)
+          instance_exec(&definition)
+          unless __strict_dsl_internal_attributes.fetch(discriminator).equal?(discriminator_attribute)
+            ::Kernel.raise ::ArgumentError, "variants cannot redeclare discriminator #{discriminator.inspect}"
+          end
+        end
+        variant_class.define_singleton_method(:===, ::Module.instance_method(:===))
+        variant_class
+      end
+      # rubocop:enable Metrics/MethodLength
+
+      def strict_union_constant_name(tag)
+        name = tag.to_s
+        unless VARIANT_NAME.match?(name)
+          raise ArgumentError, "variant name must be lower snake_case, got #{name.inspect}"
+        end
+
+        name.split("_").map { |part| part.sub(/\A./, &:upcase) }.join
+      end
+    end
+
+    module Instance
+      def initialize(...)
+        raise TypeError, "cannot instantiate union #{self.class} directly; instantiate one of its variants"
+      end
+    end
+  end
+end

--- a/lib/strict/unions/coercer.rb
+++ b/lib/strict/unions/coercer.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module Strict
+  module Unions
+    class Coercer
+      NOT_PROVIDED = ::Object.new.freeze
+      private_constant :NOT_PROVIDED
+
+      def initialize(union_class, discriminator:, variants:)
+        @union_class = union_class
+        @discriminator = discriminator
+        @variants = variants
+      end
+
+      def call(value)
+        return value if value.nil? || union_class === value
+        return value unless value.respond_to?(:to_h)
+
+        coerce(value.to_h)
+      end
+
+      private
+
+      attr_reader :union_class, :discriminator, :variants
+
+      def coerce(hash)
+        tag = tag_from(hash)
+        canonical_tag = tag.is_a?(String) ? tag.to_sym : tag
+        variant_for(canonical_tag, original_tag: tag).coercer.call(hash.merge(discriminator => canonical_tag))
+      end
+
+      def tag_from(hash)
+        tag = hash.fetch(discriminator) { hash.fetch(discriminator.to_s, NOT_PROVIDED) }
+        if tag.equal?(NOT_PROVIDED)
+          raise ArgumentError, "missing discriminator #{discriminator.inspect} for #{union_class}"
+        end
+
+        tag
+      end
+
+      def variant_for(tag, original_tag:)
+        variants.fetch(tag)
+      rescue KeyError
+        expected = variants.keys.map(&:inspect).join(", ")
+        raise ArgumentError,
+              "unknown discriminator #{discriminator.inspect} for #{union_class}: #{original_tag.inspect}; " \
+              "expected one of #{expected}"
+      end
+    end
+  end
+end

--- a/lib/strict/unions/coercer.rb
+++ b/lib/strict/unions/coercer.rb
@@ -25,8 +25,8 @@ module Strict
 
       def coerce(hash)
         tag = tag_from(hash)
-        canonical_tag = tag.is_a?(String) ? tag.to_sym : tag
-        variant_for(canonical_tag, original_tag: tag).coercer.call(hash.merge(discriminator => canonical_tag))
+        variant = variant_for(normalized_tag(tag), original_tag: tag)
+        variant.variant_class.coercer.call(hash.merge(discriminator => variant.tag))
       end
 
       def tag_from(hash)
@@ -41,10 +41,14 @@ module Strict
       def variant_for(tag, original_tag:)
         variants.fetch(tag)
       rescue KeyError
-        expected = variants.keys.map(&:inspect).join(", ")
+        expected = variants.values.map { |variant| variant.tag.inspect }.join(", ")
         raise ArgumentError,
               "unknown discriminator #{discriminator.inspect} for #{union_class}: #{original_tag.inspect}; " \
               "expected one of #{expected}"
+      end
+
+      def normalized_tag(tag)
+        tag.is_a?(String) ? tag.to_sym : tag
       end
     end
   end

--- a/lib/strict/value.rb
+++ b/lib/strict/value.rb
@@ -10,6 +10,11 @@ module Strict
       self.class.new(**to_h, **attributes)
     end
 
+    def deconstruct_keys(keys)
+      attributes = to_h
+      keys ? attributes.slice(*keys) : attributes
+    end
+
     def eql?(other)
       return false unless self.class.equal?(other.class)
 

--- a/sig/strict.rbs
+++ b/sig/strict.rbs
@@ -95,6 +95,16 @@ module Strict
     def coercer: () -> _Coercer[untyped, untyped]
   end
 
+  # Extend this type-only interface in application signatures for classes that
+  # include Strict::Union.
+  interface _UnionClass
+    def discriminator: (String | Symbol name) -> void
+    def variant: (String | Symbol name) -> void
+               | (String | Symbol name) { () [self: _AttributesDsl] -> untyped } -> void
+    def coercer: () -> _Coercer[untyped, untyped]
+    def ===: (untyped value) -> bool
+  end
+
   def self.configuration: () -> Configuration
   def self.configure: () { (Configuration configuration) -> untyped } -> void
   def self.with_overrides: (
@@ -106,6 +116,7 @@ module Strict
     include _AttributesInstance
 
     def with: (**untyped attributes) -> self
+    def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
     def ==: (untyped other) -> bool
     def eql?: (untyped other) -> bool
     def hash: () -> Integer
@@ -120,6 +131,9 @@ module Strict
 
   module Interface
     def implementation: () -> untyped
+  end
+
+  module Union
   end
 
   class Configuration

--- a/sig/strict.rbs
+++ b/sig/strict.rbs
@@ -103,8 +103,8 @@ module Strict
   # include Strict::Union.
   interface _UnionClass
     def discriminator: (String | Symbol name) -> void
-    def variant: (String | Symbol name) -> void
-               | (String | Symbol name) { () [self: _UnionVariantClass] -> untyped } -> void
+    def variant: (String | Symbol name, ?tag: String | Symbol) -> void
+               | (String | Symbol name, ?tag: String | Symbol) { () [self: _UnionVariantClass] -> untyped } -> void
     def coercer: () -> _Coercer[untyped, untyped]
     def ===: (untyped value) -> bool
   end

--- a/sig/strict.rbs
+++ b/sig/strict.rbs
@@ -95,12 +95,16 @@ module Strict
     def coercer: () -> _Coercer[untyped, untyped]
   end
 
+  interface _UnionVariantClass
+    def attributes: () { () [self: _AttributesDsl] -> untyped } -> void
+  end
+
   # Extend this type-only interface in application signatures for classes that
   # include Strict::Union.
   interface _UnionClass
     def discriminator: (String | Symbol name) -> void
     def variant: (String | Symbol name) -> void
-               | (String | Symbol name) { () [self: _AttributesDsl] -> untyped } -> void
+               | (String | Symbol name) { () [self: _UnionVariantClass] -> untyped } -> void
     def coercer: () -> _Coercer[untyped, untyped]
     def ===: (untyped value) -> bool
   end

--- a/spec/strict/strict_public_api_spec.rb
+++ b/spec/strict/strict_public_api_spec.rb
@@ -9,11 +9,13 @@ RSpec.describe Strict do
       object_class = Class.new { include Strict::Object }
       method_class = Class.new { include Strict::Method }
       interface_class = Class.new { include Strict::Interface }
+      union_class = Class.new { include Strict::Union }
 
       expect(value_class).to respond_to(:attributes)
       expect(object_class).to respond_to(:attributes)
       expect(method_class).to respond_to(:sig)
       expect(interface_class).to respond_to(:expose)
+      expect(union_class).to respond_to(:discriminator, :variant, :coercer)
     end
   end
 

--- a/spec/strict/union_spec.rb
+++ b/spec/strict/union_spec.rb
@@ -1,0 +1,170 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Strict::Union do
+  let(:union_class) do
+    Class.new do
+      include Strict::Union
+
+      discriminator :status
+
+      variant :authorized do
+        authorization_id String
+        amount_in_cents Integer
+      end
+
+      variant :declined do
+        reason String
+      end
+    end
+  end
+
+  it "generates tagged Strict::Value subclasses" do
+    authorized = union_class::Authorized.new(authorization_id: "auth_123", amount_in_cents: 1_000)
+    equal_authorized = union_class::Authorized.new(authorization_id: "auth_123", amount_in_cents: 1_000)
+    declined = union_class::Declined.new(reason: "insufficient_funds")
+
+    expect(union_class::Authorized.superclass).to be(union_class)
+    expect(union_class::Authorized < Strict::Value).to be(true)
+    expect(authorized.to_h).to eq(status: :authorized, authorization_id: "auth_123", amount_in_cents: 1_000)
+    expect(declined.to_h).to eq(status: :declined, reason: "insufficient_funds")
+    expect(authorized).to eq(equal_authorized)
+    expect(authorized.hash).to eq(equal_authorized.hash)
+    expect(authorized.with(amount_in_cents: 2_000).amount_in_cents).to eq(2_000)
+    expect(union_class === authorized).to be(true)
+    expect(union_class === declined).to be(true)
+  end
+
+  it "dispatches symbol- and string-keyed hashes by symbol or string tags" do
+    symbol_input = union_class.coercer.call(status: :authorized, authorization_id: "auth_123", amount_in_cents: 1_000)
+    string_input = union_class.coercer.call("status" => "declined", "reason" => "insufficient_funds")
+
+    expect(symbol_input).to eq(
+      union_class::Authorized.new(authorization_id: "auth_123", amount_in_cents: 1_000)
+    )
+    expect(string_input).to eq(union_class::Declined.new(reason: "insufficient_funds"))
+  end
+
+  it "leaves existing members, nil, and non-hash-like values unchanged" do
+    member = union_class::Declined.new(reason: "insufficient_funds")
+
+    expect(union_class.coercer.call(member)).to be(member)
+    expect(union_class.coercer.call(nil)).to be_nil
+    expect(union_class.coercer.call("declined")).to eq("declined")
+  end
+
+  it "rejects missing and unknown discriminators precisely" do
+    expect do
+      union_class.coercer.call(reason: "insufficient_funds")
+    end.to raise_error(ArgumentError, /missing discriminator :status/)
+
+    expect do
+      union_class.coercer.call(status: :pending)
+    end.to raise_error(ArgumentError, /unknown discriminator :status.*:pending/)
+  end
+
+  it "requires one explicit discriminator before variants or coercion" do
+    incomplete_union = Class.new { include Strict::Union }
+
+    expect { incomplete_union.variant(:pending) }.to raise_error(ArgumentError, /declare a discriminator/)
+    expect { incomplete_union.coercer }.to raise_error(ArgumentError, /declare a discriminator/)
+  end
+
+  it "prohibits direct base construction and keeps membership closed" do
+    member_subclass = Class.new(union_class::Declined)
+    member_subclass_instance = member_subclass.new(reason: "insufficient_funds")
+
+    expect { union_class.new }.to raise_error(TypeError, /cannot instantiate union/)
+    expect(union_class === member_subclass_instance).to be(false)
+    expect(union_class::Declined === member_subclass_instance).to be(true)
+  end
+
+  it "keeps each variant discriminator fixed" do
+    authorized = union_class::Authorized.new(
+      status: :authorized,
+      authorization_id: "auth_123",
+      amount_in_cents: 1_000
+    )
+
+    expect(authorized.status).to eq(:authorized)
+    expect do
+      union_class::Authorized.new(
+        status: :declined,
+        authorization_id: "auth_123",
+        amount_in_cents: 1_000
+      )
+    end.to raise_error(Strict::InitializationError)
+  end
+
+  it "supports standard Ruby class and attribute patterns" do
+    stub_const("PatternResult", union_class)
+    authorized = PatternResult::Authorized.new(authorization_id: "auth_123", amount_in_cents: 1_000)
+
+    result = case authorized
+             in PatternResult::Authorized(authorization_id:, amount_in_cents:)
+               [authorization_id, amount_in_cents]
+             else
+               nil
+             end
+
+    expect(result).to eq(["auth_123", 1_000])
+  end
+
+  it "generates PascalCase constants from lower snake_case tags and permits empty variants" do
+    generated_union = Class.new do
+      include Strict::Union
+
+      discriminator :kind
+      variant :requires_action
+    end
+
+    expect(generated_union::RequiresAction.new.to_h).to eq(kind: :requires_action)
+  end
+
+  it "rejects duplicate declarations and generated constant collisions" do
+    duplicate_discriminator = Class.new do
+      include Strict::Union
+
+      discriminator :kind
+    end
+    duplicate_variant = Class.new do
+      include Strict::Union
+
+      discriminator :kind
+      variant :some_result
+    end
+    constant_collision = Class.new do
+      include Strict::Union
+
+      discriminator :kind
+      const_set(:Existing, Class.new)
+    end
+
+    expect do
+      duplicate_discriminator.discriminator(:type)
+    end.to raise_error(ArgumentError, /discriminator already declared/)
+    expect do
+      duplicate_variant.variant("some_result")
+    end.to raise_error(ArgumentError, /variant :some_result already declared/)
+    expect do
+      constant_collision.variant(:existing)
+    end.to raise_error(ArgumentError, /constant Existing is already defined/)
+    expect do
+      duplicate_variant.variant(:not_valid!)
+    end.to raise_error(ArgumentError, /variant name must be lower snake_case/)
+  end
+
+  it "rejects discriminator attributes in variant declarations" do
+    expect do
+      Class.new do
+        include Strict::Union
+
+        discriminator :kind
+        variant :invalid do
+          kind Symbol
+        end
+      end
+    end.to raise_error(ArgumentError, /cannot redeclare discriminator :kind/)
+  end
+end

--- a/spec/strict/union_spec.rb
+++ b/spec/strict/union_spec.rb
@@ -46,6 +46,21 @@ RSpec.describe Strict::Union do
     expect(string_input).to eq(union_class::Declined.new(reason: "insufficient_funds"))
   end
 
+  it "works as an attribute validator and coercer" do
+    result_class = union_class
+    container_class = Class.new do
+      include Strict::Value
+
+      attributes do
+        result result_class, coerce: result_class.coercer
+      end
+    end
+
+    container = container_class.new(result: { "status" => "declined", "reason" => "insufficient_funds" })
+
+    expect(container.result).to eq(union_class::Declined.new(reason: "insufficient_funds"))
+  end
+
   it "leaves existing members, nil, and non-hash-like values unchanged" do
     member = union_class::Declined.new(reason: "insufficient_funds")
 

--- a/spec/strict/union_spec.rb
+++ b/spec/strict/union_spec.rb
@@ -46,19 +46,25 @@ RSpec.describe Strict::Union do
     expect(string_input).to eq(union_class::Declined.new(reason: "insufficient_funds"))
   end
 
-  it "works as an attribute validator and coercer" do
+  it "works as an attribute validator with optional coercion" do
     result_class = union_class
     container_class = Class.new do
       include Strict::Value
 
       attributes do
-        result result_class, coerce: result_class.coercer
+        payment_result result_class
+        coerced_payment_result result_class, coerce: result_class.coercer
       end
     end
+    payment_result = union_class::Declined.new(reason: "insufficient_funds")
 
-    container = container_class.new(result: { "status" => "declined", "reason" => "insufficient_funds" })
+    container = container_class.new(
+      payment_result: payment_result,
+      coerced_payment_result: { "status" => "declined", "reason" => "insufficient_funds" }
+    )
 
-    expect(container.result).to eq(union_class::Declined.new(reason: "insufficient_funds"))
+    expect(container.payment_result).to be(payment_result)
+    expect(container.coerced_payment_result).to eq(payment_result)
   end
 
   it "leaves existing members, nil, and non-hash-like values unchanged" do

--- a/spec/strict/union_spec.rb
+++ b/spec/strict/union_spec.rb
@@ -10,12 +10,16 @@ RSpec.describe Strict::Union do
       discriminator :status
 
       variant :authorized do
-        authorization_id String
-        amount_in_cents Integer
+        attributes do
+          authorization_id String
+          amount_in_cents Integer
+        end
       end
 
       variant :declined do
-        reason String
+        attributes do
+          reason String
+        end
       end
     end
   end
@@ -34,6 +38,31 @@ RSpec.describe Strict::Union do
     expect(authorized.with(amount_in_cents: 2_000).amount_in_cents).to eq(2_000)
     expect(union_class === authorized).to be(true)
     expect(union_class === declined).to be(true)
+  end
+
+  it "defines behavior on generated variant classes" do
+    behavior = Module.new do
+      def successful? = true
+    end
+    result_class = Class.new do
+      include Strict::Union
+
+      discriminator :status
+
+      variant :authorized do
+        include behavior
+
+        attributes do
+          authorization_id String
+        end
+
+        def description = "Authorized as #{authorization_id}"
+      end
+    end
+    authorized = result_class::Authorized.new(authorization_id: "auth_123")
+
+    expect(authorized.successful?).to be(true)
+    expect(authorized.description).to eq("Authorized as auth_123")
   end
 
   it "dispatches symbol- and string-keyed hashes by symbol or string tags" do
@@ -145,6 +174,20 @@ RSpec.describe Strict::Union do
     expect(generated_union::RequiresAction.new.to_h).to eq(kind: :requires_action)
   end
 
+  it "rejects multiple attribute declarations for one variant" do
+    expect do
+      Class.new do
+        include Strict::Union
+
+        discriminator :kind
+        variant :invalid do
+          attributes { first String }
+          attributes { second String }
+        end
+      end
+    end.to raise_error(ArgumentError, /attributes already declared for variant :invalid/)
+  end
+
   it "rejects duplicate declarations and generated constant collisions" do
     duplicate_discriminator = Class.new do
       include Strict::Union
@@ -185,7 +228,9 @@ RSpec.describe Strict::Union do
 
         discriminator :kind
         variant :invalid do
-          kind Symbol
+          attributes do
+            kind Symbol
+          end
         end
       end
     end.to raise_error(ArgumentError, /cannot redeclare discriminator :kind/)

--- a/spec/strict/union_spec.rb
+++ b/spec/strict/union_spec.rb
@@ -82,19 +82,21 @@ RSpec.describe Strict::Union do
 
   it "keeps each variant discriminator fixed" do
     authorized = union_class::Authorized.new(
-      status: :authorized,
+      status: "authorized",
       authorization_id: "auth_123",
       amount_in_cents: 1_000
     )
 
     expect(authorized.status).to eq(:authorized)
     expect do
-      union_class::Authorized.new(
-        status: :declined,
-        authorization_id: "auth_123",
-        amount_in_cents: 1_000
-      )
-    end.to raise_error(Strict::InitializationError)
+      Strict.with_overrides(sample_rate: 0) do
+        union_class::Authorized.new(
+          status: :declined,
+          authorization_id: "auth_123",
+          amount_in_cents: 1_000
+        )
+      end
+    end.to raise_error(ArgumentError, /discriminator :status must equal :authorized/)
   end
 
   it "supports standard Ruby class and attribute patterns" do

--- a/spec/strict/union_spec.rb
+++ b/spec/strict/union_spec.rb
@@ -75,6 +75,27 @@ RSpec.describe Strict::Union do
     expect(string_input).to eq(union_class::Declined.new(reason: "insufficient_funds"))
   end
 
+  it "separates variant names from discriminator tags" do
+    result_class = Class.new do
+      include Strict::Union
+
+      discriminator :status
+      variant :authorized, tag: "some-string" do
+        attributes do
+          authorization_id String
+        end
+      end
+    end
+
+    authorized = result_class::Authorized.new(status: :"some-string", authorization_id: "auth_123")
+    string_input = result_class.coercer.call(status: "some-string", authorization_id: "auth_123")
+    symbol_input = result_class.coercer.call(status: :"some-string", authorization_id: "auth_123")
+
+    expect(authorized.to_h).to eq(status: "some-string", authorization_id: "auth_123")
+    expect(string_input).to eq(authorized)
+    expect(symbol_input).to eq(authorized)
+  end
+
   it "works as an attribute validator with optional coercion" do
     result_class = union_class
     container_class = Class.new do
@@ -163,7 +184,7 @@ RSpec.describe Strict::Union do
     expect(result).to eq(["auth_123", 1_000])
   end
 
-  it "generates PascalCase constants from lower snake_case tags and permits empty variants" do
+  it "generates PascalCase constants from lower snake_case names and permits empty variants" do
     generated_union = Class.new do
       include Strict::Union
 
@@ -186,6 +207,31 @@ RSpec.describe Strict::Union do
         end
       end
     end.to raise_error(ArgumentError, /attributes already declared for variant :invalid/)
+  end
+
+  it "rejects equivalent duplicate discriminator tags" do
+    duplicate_tag = Class.new do
+      include Strict::Union
+
+      discriminator :kind
+      variant :first, tag: "same"
+    end
+
+    expect do
+      duplicate_tag.variant(:second, tag: :same)
+    end.to raise_error(ArgumentError, /tag :same already declared/)
+  end
+
+  it "requires discriminator tags to be strings or symbols" do
+    invalid_tag = Class.new do
+      include Strict::Union
+
+      discriminator :kind
+    end
+
+    expect do
+      invalid_tag.variant(:invalid, tag: 1)
+    end.to raise_error(ArgumentError, /tag must be a String or Symbol/)
   end
 
   it "rejects duplicate declarations and generated constant collisions" do

--- a/spec/strict/value_spec.rb
+++ b/spec/strict/value_spec.rb
@@ -124,6 +124,13 @@ RSpec.describe Strict::Value do
     expect(instance.to_h).to eq(foo: 1, bar: "2", baz: "3")
   end
 
+  it "deconstructs attributes for pattern matching" do
+    instance = build(:value)
+
+    expect(instance.deconstruct_keys(nil)).to eq(foo: 1, bar: "2", baz: "3")
+    expect(instance.deconstruct_keys(%i[foo missing])).to eq(foo: 1)
+  end
+
   it "can be inspected" do
     instance = build(:value)
 


### PR DESCRIPTION
## Summary

- add closed discriminated unions with generated `Strict::Value` variant subclasses
- dispatch symbol- or string-keyed hashes through an explicit discriminator and union coercer
- let variant blocks define behavior, include modules, and declare one nested `attributes` block
- support standard Ruby class and attribute pattern matching
- document the public API and provide RBS signatures

## Design

Union roots own variant registration, exact membership, unique tags, and coercion dispatch. Generated variants reuse `Strict::Value` for attributes, validation, defaults, equality, hashing, conversion, and pattern matching. Discriminator coercion keeps each tag fixed even when sampled validation is disabled.

## Verification

- `bundle exec rake`
- 250 examples, 0 failures
- 83 files inspected by RuboCop, no offenses
- RBS validation passed
- README union example executed successfully
