### PR TITLE
Support inherited and shared attributes

### DIFF
--- a/API.md
+++ b/API.md
@@ -40,7 +40,7 @@ Both capabilities provide:
 - `==` and `eql?`, based on exact class and attribute values;
 - `hash`, consistent with `eql?`.
 
-A subclass that does not declare attributes inherits its parent's supported attribute behavior. Attribute redeclaration, multiple `attributes` blocks, generated-method collisions, and subclass attribute replacement or merging are outside the compatibility boundary.
+A subclass inherits its parent's attributes. A subclass `attributes` block adds its declarations after the inherited declarations without changing the parent. Attribute redeclaration, multiple `attributes` blocks on the same class, and generated-method collisions are outside the compatibility boundary.
 
 #### Attribute introspection
 
@@ -81,6 +81,10 @@ class PaymentResult
 
   discriminator :status
 
+  attributes do
+    request_id String
+  end
+
   variant :authorized, tag: "payment.authorized" do
     attributes do
       authorization_id String
@@ -100,16 +104,19 @@ class PaymentResult
 end
 ```
 
-There is no default discriminator. A variant name must be a lower snake-case string or symbol, and Strict generates its PascalCase nested subclass. By default, the discriminator tag is the name's corresponding symbol. The optional `tag:` can assign a different string or symbol. For example, `variant :requires_action, tag: "action-required"` generates `PaymentResult::RequiresAction < PaymentResult` with the tag `"action-required"`.
+There is no default discriminator. A union can declare zero or one `attributes` block before its variants. Strict shares these attributes across every variant. The declaration can appear before or after the discriminator, but it cannot redeclare the discriminator.
 
-The variant block configures the generated subclass. It can include modules, define methods, and contain zero or one `attributes` block. Strict combines that block with an implicit first attribute containing the discriminator's fixed default value:
+A variant name must be a lower snake-case string or symbol, and Strict generates its PascalCase nested subclass. By default, the discriminator tag is the name's corresponding symbol. The optional `tag:` can assign a different string or symbol. For example, `variant :requires_action, tag: "action-required"` generates `PaymentResult::RequiresAction < PaymentResult` with the tag `"action-required"`.
+
+The variant block configures the generated subclass. It can include modules, define methods, and contain zero or one `attributes` block. Strict combines the discriminator, shared union attributes, and variant attributes in that order. The discriminator is an implicit first attribute with a fixed default value:
 
 ```ruby
 PaymentResult::Authorized.new(
+  request_id: "request_123",
   authorization_id: "auth_123",
   amount_in_cents: 1_000
 ).to_h
-# => { status: "payment.authorized", authorization_id: "auth_123", amount_in_cents: 1_000 }
+# => { status: "payment.authorized", request_id: "request_123", authorization_id: "auth_123", amount_in_cents: 1_000 }
 ```
 
 Variants therefore use the documented `Strict::Value` behavior for initialization, validation, coercion, defaults, copying, equality, hashing, conversion, inspection, and pattern matching. A variant declaration cannot redeclare the discriminator. The union base cannot be instantiated directly.
@@ -132,7 +139,7 @@ payment_result PaymentResult
 coerced_payment_result PaymentResult, coerce: PaymentResult.coercer
 ```
 
-Declaring a discriminator more than once, declaring equivalent duplicate string or symbol tags, using an invalid variant name or tag, replacing an existing generated constant, declaring multiple attribute blocks, or redeclaring the discriminator raises `ArgumentError`. Declaration return values, generated-class reflection details, and the exact text of declaration and coercion errors are outside the compatibility boundary.
+Declaring a discriminator more than once, declaring equivalent duplicate string or symbol tags, using an invalid variant name or tag, replacing an existing generated constant, declaring multiple union or variant attribute blocks, declaring union attributes after a variant, or redeclaring the discriminator raises `ArgumentError`. Declaration return values, generated-class reflection details, and the exact text of declaration and coercion errors are outside the compatibility boundary.
 
 ### Signed methods
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Define and characterize the supported next-major API in `API.md`, provide RBS signatures for that boundary, validate them in the default checks, and add repeatable timing and allocation benchmark tooling.
 - Add closed discriminated unions whose generated variants use `Strict::Value` for attributes and value behavior.
+- Add inherited value and object attribute declarations and shared union attributes.
 
 ### Breaking changes
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,24 @@ Money.new(amount_in_cents: 100_00) == Money.new(amount_in_cents: 100_00)
 # => true
 ```
 
+Subclasses can add attributes while retaining their inherited attributes:
+
+```rb
+class Person
+  include Strict::Value
+
+  attributes do
+    name String
+  end
+end
+
+class Employee < Person
+  attributes do
+    employee_id String
+  end
+end
+```
+
 ### `Strict::Union`
 
 ```rb
@@ -60,6 +78,10 @@ class PaymentResult
   include Strict::Union
 
   discriminator :status
+
+  attributes do
+    request_id String
+  end
 
   variant :authorized, tag: "payment.authorized" do
     attributes do
@@ -80,20 +102,22 @@ class PaymentResult
 end
 
 authorized = PaymentResult::Authorized.new(
+  request_id: "request_123",
   authorization_id: "auth_123",
   amount_in_cents: 1_000
 )
 authorized.to_h
-# => { status: "payment.authorized", authorization_id: "auth_123", amount_in_cents: 1_000 }
+# => { status: "payment.authorized", request_id: "request_123", authorization_id: "auth_123", amount_in_cents: 1_000 }
 
 authorized.successful?
 # => true
 
 result = PaymentResult.coercer.call(
   "status" => "declined",
+  "request_id" => "request_456",
   "reason" => "insufficient_funds"
 )
-# => #<PaymentResult::Declined status=:declined reason="insufficient_funds">
+# => #<PaymentResult::Declined status=:declined request_id="request_456" reason="insufficient_funds">
 
 case result
 in PaymentResult::Authorized(authorization_id:)

--- a/lib/strict/attributes/dsl.rb
+++ b/lib/strict/attributes/dsl.rb
@@ -4,8 +4,8 @@ module Strict
   module Attributes
     class Dsl < BasicObject
       class << self
-        def run(&)
-          dsl = new
+        def run(attributes: [], &)
+          dsl = new(attributes: attributes)
           dsl.instance_eval(&)
           ::Strict::Attributes::Configuration.new(attributes: dsl.__strict_dsl_internal_attributes.values)
         end
@@ -16,8 +16,8 @@ module Strict
 
       attr_reader :__strict_dsl_internal_attributes
 
-      def initialize
-        @__strict_dsl_internal_attributes = {}
+      def initialize(attributes:)
+        @__strict_dsl_internal_attributes = attributes.to_h { |attribute| [attribute.name, attribute] }
       end
 
       def strict_attribute(*, **)

--- a/lib/strict/attributes/generated_methods.rb
+++ b/lib/strict/attributes/generated_methods.rb
@@ -6,7 +6,8 @@ module Strict
       def self.install_on(target, writable:)
         target.define_singleton_method(:attributes) do |&block|
           block ||= -> {}
-          configuration = Strict::Attributes::Dsl.run(&block)
+          inherited_attributes = respond_to?(:strict_attributes) ? strict_attributes : []
+          configuration = Strict::Attributes::Dsl.run(attributes: inherited_attributes, &block)
           include Strict::Attributes::GeneratedMethods.new(configuration, writable: writable)
           include Strict::Attributes::Instance
           extend Strict::Attributes::Class

--- a/lib/strict/union.rb
+++ b/lib/strict/union.rb
@@ -11,15 +11,29 @@ module Strict
       union_class.extend(ClassMethods)
       union_class.include(Instance)
       union_class.instance_variable_set(:@strict_union_discriminator, nil)
+      union_class.instance_variable_set(:@strict_union_attributes, nil)
       union_class.instance_variable_set(:@strict_union_variant_names, {})
       union_class.instance_variable_set(:@strict_union_variants, {})
     end
 
-    module ClassMethods
+    module ClassMethods # rubocop:disable Metrics/ModuleLength
       def discriminator(name)
         raise ArgumentError, "discriminator already declared for #{self}" if @strict_union_discriminator
 
-        @strict_union_discriminator = name.to_sym
+        discriminator = name.to_sym
+        strict_union_validate_attributes!(@strict_union_attributes, discriminator)
+        @strict_union_discriminator = discriminator
+        nil
+      end
+
+      def attributes(&definition)
+        raise ArgumentError, "attributes already declared for #{self}" if @strict_union_attributes
+        raise ArgumentError, "attributes must be declared before variants for #{self}" if @strict_union_variants.any?
+
+        definition ||= -> {}
+        attributes = Attributes::Dsl.run(&definition)
+        strict_union_validate_attributes!(attributes, @strict_union_discriminator)
+        @strict_union_attributes = attributes
         nil
       end
 
@@ -92,16 +106,28 @@ module Strict
         attribute_definition
       end
 
+      # rubocop:disable Metrics/MethodLength
       def strict_union_define_variant_attributes(variant_class, discriminator, tag, attribute_definition)
         discriminator_coercer = strict_union_discriminator_coercer(discriminator, tag)
+        shared_attributes = @strict_union_attributes
         variant_class.attributes do
           strict_attribute discriminator, tag, default_value: tag, coerce: discriminator_coercer
           discriminator_attribute = __strict_dsl_internal_attributes.fetch(discriminator)
+          shared_attributes&.each do |attribute|
+            __strict_dsl_internal_attributes[attribute.name] = attribute
+          end
           instance_exec(&attribute_definition) if attribute_definition
           unless __strict_dsl_internal_attributes.fetch(discriminator).equal?(discriminator_attribute)
             ::Kernel.raise ::ArgumentError, "variants cannot redeclare discriminator #{discriminator.inspect}"
           end
         end
+      end
+      # rubocop:enable Metrics/MethodLength
+
+      def strict_union_validate_attributes!(attributes, discriminator)
+        return unless discriminator && attributes&.any? { |attribute| attribute.name.eql?(discriminator) }
+
+        raise ArgumentError, "union attributes cannot redeclare discriminator #{discriminator.inspect}"
       end
 
       def strict_union_discriminator_coercer(discriminator, tag)
@@ -131,7 +157,7 @@ module Strict
 
         name.split("_").map { |part| part.sub(/\A./, &:upcase) }.join
       end
-    end
+    end # rubocop:enable Metrics/ModuleLength
 
     module Instance
       def initialize(...)

--- a/sig/strict.rbs
+++ b/sig/strict.rbs
@@ -102,6 +102,7 @@ module Strict
   # Extend this type-only interface in application signatures for classes that
   # include Strict::Union.
   interface _UnionClass
+    def attributes: () { () [self: _AttributesDsl] -> untyped } -> void
     def discriminator: (String | Symbol name) -> void
     def variant: (String | Symbol name, ?tag: String | Symbol) -> void
                | (String | Symbol name, ?tag: String | Symbol) { () [self: _UnionVariantClass] -> untyped } -> void

--- a/spec/strict/object_spec.rb
+++ b/spec/strict/object_spec.rb
@@ -8,6 +8,28 @@ RSpec.describe Strict::Object do
     expect(ObjectClass.strict_attributes.map(&:name)).to eq(%i[foo bar baz])
   end
 
+  it "combines inherited and subclass attributes with writers" do
+    parent_class = Class.new do
+      include Strict::Object
+
+      attributes do
+        name String
+      end
+    end
+    child_class = Class.new(parent_class) do
+      attributes do
+        employee_id String
+      end
+    end
+    employee = child_class.new(name: "Ada", employee_id: "employee_123")
+
+    employee.name = "Grace"
+    employee.employee_id = "employee_456"
+
+    expect(employee.to_h).to eq(name: "Grace", employee_id: "employee_456")
+    expect(parent_class.strict_attributes.map(&:name)).to eq([:name])
+  end
+
   it "exposes writer methods" do
     instance = build(:strict_object)
     instance.foo = 2

--- a/spec/strict/strict_public_api_spec.rb
+++ b/spec/strict/strict_public_api_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Strict do
       expect(object_class).to respond_to(:attributes)
       expect(method_class).to respond_to(:sig)
       expect(interface_class).to respond_to(:expose)
-      expect(union_class).to respond_to(:discriminator, :variant, :coercer)
+      expect(union_class).to respond_to(:attributes, :discriminator, :variant, :coercer)
     end
   end
 

--- a/spec/strict/union_spec.rb
+++ b/spec/strict/union_spec.rb
@@ -40,6 +40,32 @@ RSpec.describe Strict::Union do
     expect(union_class === declined).to be(true)
   end
 
+  it "shares union attributes across variants" do
+    result_class = Class.new do
+      include Strict::Union
+
+      discriminator :status
+
+      attributes do
+        request_id String
+      end
+
+      variant :authorized do
+        attributes do
+          authorization_id String
+        end
+      end
+
+      variant :declined
+    end
+
+    authorized = result_class::Authorized.new(request_id: "request_123", authorization_id: "auth_123")
+    declined = result_class.coercer.call(status: :declined, request_id: "request_456")
+
+    expect(authorized.to_h).to eq(status: :authorized, request_id: "request_123", authorization_id: "auth_123")
+    expect(declined.to_h).to eq(status: :declined, request_id: "request_456")
+  end
+
   it "defines behavior on generated variant classes" do
     behavior = Module.new do
       def successful? = true
@@ -207,6 +233,50 @@ RSpec.describe Strict::Union do
         end
       end
     end.to raise_error(ArgumentError, /attributes already declared for variant :invalid/)
+  end
+
+  it "requires one union attribute declaration before variants" do
+    result_class = Class.new do
+      include Strict::Union
+
+      discriminator :kind
+      attributes { request_id String }
+    end
+
+    expect do
+      result_class.attributes { account_id String }
+    end.to raise_error(ArgumentError, /attributes already declared/)
+
+    result_class_without_attributes = Class.new do
+      include Strict::Union
+
+      discriminator :kind
+      variant :complete
+    end
+
+    expect do
+      result_class_without_attributes.attributes { request_id String }
+    end.to raise_error(ArgumentError, /attributes must be declared before variants/)
+  end
+
+  it "rejects discriminator attributes in union declarations" do
+    expect do
+      Class.new do
+        include Strict::Union
+
+        discriminator :kind
+        attributes { kind Symbol }
+      end
+    end.to raise_error(ArgumentError, /cannot redeclare discriminator :kind/)
+
+    expect do
+      Class.new do
+        include Strict::Union
+
+        attributes { kind Symbol }
+        discriminator :kind
+      end
+    end.to raise_error(ArgumentError, /cannot redeclare discriminator :kind/)
   end
 
   it "rejects equivalent duplicate discriminator tags" do

--- a/spec/strict/value_spec.rb
+++ b/spec/strict/value_spec.rb
@@ -8,6 +8,27 @@ RSpec.describe Strict::Value do
     expect(ValueClass.strict_attributes.map(&:name)).to eq(%i[foo bar baz])
   end
 
+  it "combines inherited and subclass attributes" do
+    person_class = Class.new do
+      include Strict::Value
+
+      attributes do
+        name String
+      end
+    end
+    employee_class = Class.new(person_class) do
+      attributes do
+        employee_id String
+      end
+    end
+
+    employee = employee_class.new(name: "Ada", employee_id: "employee_123")
+
+    expect(employee.to_h).to eq(name: "Ada", employee_id: "employee_123")
+    expect(employee_class.strict_attributes.map(&:name)).to eq(%i[name employee_id])
+    expect(person_class.strict_attributes.map(&:name)).to eq([:name])
+  end
+
   it "does not expose writer methods" do
     instance = build(:value)
 


### PR DESCRIPTION
## Summary

- merge inherited attributes into subclass declarations without changing the parent
- share union-level attributes across all generated variants
- document the new declarations and expose the union API in RBS

## Verification

- `bundle exec rake`
