### PR TITLE
Add structured validation failures

### DIFF
--- a/API.md
+++ b/API.md
@@ -177,6 +177,7 @@ Interface subclassing and re-exposing a method are outside the compatibility bou
 ## Validators and coercers
 
 Any object that implements `===` can be a validator. This includes classes, modules, literals, and custom validators.
+When a custom validator rejects a value, Strict reports that validator in one `:invalid` violation. A custom validator does not need to implement a separate failure protocol.
 
 Attribute and method DSL blocks provide these validator constructors:
 
@@ -224,6 +225,17 @@ These exception classes are public and inherit from `Strict::Error`:
 
 Messages identify the failure but their exact wording and formatting are not fixed. Exception constructor signatures are internal.
 
+Every `Strict::Error` provides `#violations`, which returns an array of `Strict::Violation` records. Assignment, initialization, method-call, and method-return errors report runtime validation and structural input failures. Other errors return an empty array.
+
+Each violation provides:
+
+- `path`: the location of the failure;
+- `code`: `:invalid`, `:missing`, or `:unexpected`;
+- `value`: the rejected or unexpected value, or `nil` for a missing value;
+- `validator`: the validator that rejected or required the value, or `nil` for an unexpected value.
+
+An attribute or parameter name is the first path segment. Array elements use zero-based indices, and hash entries use their actual keys. Unexpected positional arguments use their zero-based argument indices. Return values start at the root, so a simple invalid return has an empty path and a nested return starts with its collection segment. `ArrayOf`, `HashOf`, and `AllOf` preserve nested failure paths. Failure order is not fixed.
+
 The supported readers are:
 
 - `AssignmentError#value`
@@ -237,6 +249,6 @@ Readers that expose attribute, parameter, or method descriptors are internal.
 
 ## Constants and implementation details
 
-`Strict::VERSION` is public. `Strict::ISSUE_TRACKER` is internal.
+`Strict::VERSION` and `Strict::Violation` are public. `Strict::ISSUE_TRACKER` is internal.
 
 `Strict::Attribute`, `Strict::Parameter`, `Strict::Return`, `strict_class_methods`, and `strict_instance_methods` are internal. The `Strict::Accessor`, `Strict::Reader`, `Strict::Attributes`, `Strict::Dsl`, `Strict::Interfaces`, `Strict::Methods`, and `Strict::Unions` namespaces and their contents are also internal.

--- a/API.md
+++ b/API.md
@@ -176,8 +176,29 @@ Interface subclassing and re-exposing a method are outside the compatibility bou
 
 ## Validators and coercers
 
-Any object that implements `===` can be a validator. This includes classes, modules, literals, and custom validators.
-When a custom validator rejects a value, Strict reports that validator in one `:invalid` violation. A custom validator does not need to implement a separate failure protocol.
+Any object that implements `===` can be a validator. This includes classes, modules, literals, and custom validators. When a validator rejects a value, Strict reports that validator in one `:invalid` violation at the current path.
+
+A custom validator can opt into nested structured failures by including `Strict::DetailedValidator` and implementing `violations(value)`. The method must return an array of `Strict::Violation` records and return an empty array when the value is valid. Each violation path is relative to the validated value; Strict prefixes paths when the validator is nested inside a declaration or a built-in detailed validator. `Strict::DetailedValidator` implements `===` from `violations`, so the custom validator does not need to implement both methods.
+
+```ruby
+class Emails
+  include Strict::DetailedValidator
+
+  def violations(value)
+    unless Array === value
+      return [Strict::Violation.new(path: [], code: :invalid, value: value, validator: Array)]
+    end
+
+    value.each_with_index.filter_map do |email, index|
+      next if String === email
+
+      Strict::Violation.new(path: [index], code: :invalid, value: email, validator: String)
+    end
+  end
+end
+```
+
+`Strict::Violation.new` accepts the four keyword arguments exposed by its readers: `path:`, `code:`, `value:`, and `validator:`. Validators that only implement `===` remain fully supported and do not need to include `Strict::DetailedValidator`.
 
 Attribute and method DSL blocks provide these validator constructors:
 
@@ -249,6 +270,6 @@ Readers that expose attribute, parameter, or method descriptors are internal.
 
 ## Constants and implementation details
 
-`Strict::VERSION` and `Strict::Violation` are public. `Strict::ISSUE_TRACKER` is internal.
+`Strict::VERSION`, `Strict::Violation`, and `Strict::DetailedValidator` are public. `Strict::ISSUE_TRACKER` is internal.
 
 `Strict::Attribute`, `Strict::Parameter`, `Strict::Return`, `strict_class_methods`, and `strict_instance_methods` are internal. The `Strict::Accessor`, `Strict::Reader`, `Strict::Attributes`, `Strict::Dsl`, `Strict::Interfaces`, `Strict::Methods`, and `Strict::Unions` namespaces and their contents are also internal.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Define and characterize the supported next-major API in `API.md`, provide RBS signatures for that boundary, validate them in the default checks, and add repeatable timing and allocation benchmark tooling.
 - Add closed discriminated unions whose generated variants use `Strict::Value` for attributes and value behavior.
 - Add inherited value and object attribute declarations and shared union attributes.
-- Add structured validation violations with paths, codes, rejected values, and validators for assignment, initialization, signed method calls, and returns.
+- Add structured validation violations with paths, codes, rejected values, and validators for assignment, initialization, signed method calls, and returns, plus an optional detailed-validator protocol for custom nested failures.
 
 ### Breaking changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Define and characterize the supported next-major API in `API.md`, provide RBS signatures for that boundary, validate them in the default checks, and add repeatable timing and allocation benchmark tooling.
 - Add closed discriminated unions whose generated variants use `Strict::Value` for attributes and value behavior.
 - Add inherited value and object attribute declarations and shared union attributes.
+- Add structured validation violations with paths, codes, rejected values, and validators for assignment, initialization, signed method calls, and returns.
 
 ### Breaking changes
 

--- a/README.md
+++ b/README.md
@@ -157,6 +157,32 @@ Stateful.new(some_state: "123") == Stateful.new(some_state: "123")
 # => false
 ```
 
+Validation errors provide structured violations with paths into nested values:
+
+```rb
+class Batch
+  include Strict::Value
+
+  attributes do
+    labels ArrayOf(String)
+  end
+end
+
+begin
+  Batch.new(labels: ["ready", 404], extra: true)
+rescue Strict::InitializationError => error
+  error.violations.map do |violation|
+    [violation.path, violation.code, violation.value, violation.validator]
+  end
+end
+# => [
+#      [[:labels, 1], :invalid, 404, String],
+#      [[:extra], :unexpected, true, nil]
+#    ]
+```
+
+The codes are `:invalid`, `:missing`, and `:unexpected`. Custom validators only need to implement `===`; Strict reports a rejected value against that validator at the current path.
+
 ### `Strict::Method`
 
 ```rb

--- a/README.md
+++ b/README.md
@@ -181,7 +181,27 @@ end
 #    ]
 ```
 
-The codes are `:invalid`, `:missing`, and `:unexpected`. Custom validators only need to implement `===`; Strict reports a rejected value against that validator at the current path.
+The codes are `:invalid`, `:missing`, and `:unexpected`. Custom validators only need to implement `===`; Strict reports a rejected value against that validator at the current path. A custom validator can include `Strict::DetailedValidator` and implement `violations(value)` when it needs to report relative nested paths:
+
+```rb
+class Emails
+  include Strict::DetailedValidator
+
+  def violations(value)
+    unless Array === value
+      return [Strict::Violation.new(path: [], code: :invalid, value: value, validator: Array)]
+    end
+
+    value.each_with_index.filter_map do |email, index|
+      next if String === email
+
+      Strict::Violation.new(path: [index], code: :invalid, value: email, validator: String)
+    end
+  end
+end
+```
+
+The module provides `===` from `violations`, and Strict prefixes each relative path with its enclosing attribute, parameter, or collection path.
 
 ### `Strict::Method`
 

--- a/lib/strict/assignment_error.rb
+++ b/lib/strict/assignment_error.rb
@@ -4,8 +4,11 @@ module Strict
   class AssignmentError < Error
     attr_reader :invalid_attribute, :value
 
-    def initialize(assignable_class:, invalid_attribute:, value:)
-      super(message_from(assignable_class: assignable_class, invalid_attribute: invalid_attribute, value: value))
+    def initialize(assignable_class:, invalid_attribute:, value:, violations: Validation::NONE)
+      super(
+        message_from(assignable_class: assignable_class, invalid_attribute: invalid_attribute, value: value),
+        violations: violations
+      )
 
       @invalid_attribute = invalid_attribute
       @value = value

--- a/lib/strict/attributes/generated_methods.rb
+++ b/lib/strict/attributes/generated_methods.rb
@@ -39,14 +39,16 @@ module Strict
           assignable_class = self.class
           value = attribute.coerce(value, for_class: assignable_class)
           configuration = Strict.configuration
+          violations = attribute.violations(value, configuration, path: [attribute.name])
 
-          if attribute.valid?(value, configuration)
+          if violations.empty?
             instance_variable_set(instance_variable, value)
           else
             raise Strict::AssignmentError.new(
               assignable_class: assignable_class,
               invalid_attribute: attribute,
-              value: value
+              value: value,
+              violations: violations
             )
           end
         end

--- a/lib/strict/attributes/generated_methods.rb
+++ b/lib/strict/attributes/generated_methods.rb
@@ -39,7 +39,7 @@ module Strict
           assignable_class = self.class
           value = attribute.coerce(value, for_class: assignable_class)
           configuration = Strict.configuration
-          violations = attribute.violations(value, configuration, path: [attribute.name])
+          violations = attribute.violations(value, configuration)
 
           if violations.empty?
             instance_variable_set(instance_variable, value)
@@ -48,7 +48,7 @@ module Strict
               assignable_class: assignable_class,
               invalid_attribute: attribute,
               value: value,
-              violations: violations
+              violations: Strict::Validation.prepend_path(violations, attribute.name)
             )
           end
         end

--- a/lib/strict/attributes/instance.rb
+++ b/lib/strict/attributes/instance.rb
@@ -9,6 +9,7 @@ module Strict
         configuration = Strict.configuration
         invalid_attributes = nil
         missing_attributes = nil
+        violations = nil
 
         initializable_class.strict_attributes.each do |attribute|
           if attributes.key?(attribute.name)
@@ -18,25 +19,35 @@ module Strict
           else
             missing_attributes ||= []
             missing_attributes << attribute.name
+            violations ||= []
+            violations << Validation.missing(attribute.validator, path: [attribute.name])
             next
           end
 
           value = attribute.coerce(value, for_class: initializable_class)
-          if attribute.valid?(value, configuration)
+          attribute_violations = attribute.violations(value, configuration)
+          if attribute_violations.empty?
             instance_variable_set(attribute.instance_variable, value)
           else
             invalid_attributes ||= {}
             invalid_attributes[attribute] = value
+            violations ||= []
+            violations.concat(Validation.prepend_path(attribute_violations, attribute.name))
           end
         end
 
         return if attributes.empty? && invalid_attributes.nil? && missing_attributes.nil?
 
+        violations ||= []
+        attributes.each do |name, value|
+          violations << Validation.unexpected(value, path: [name])
+        end
         raise InitializationError.new(
           initializable_class: initializable_class,
           remaining_attributes: Set.new(attributes.keys),
           invalid_attributes: invalid_attributes,
-          missing_attributes: missing_attributes
+          missing_attributes: missing_attributes,
+          violations: violations
         )
       end
       # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity

--- a/lib/strict/declaration.rb
+++ b/lib/strict/declaration.rb
@@ -49,6 +49,7 @@ module Strict
       @default_generator = default_generator
       @coercer = coercer
       @optional = !default_generator.equal?(NOT_PROVIDED)
+      @detailed_validator = DetailedValidator === validator
     end
 
     def optional?
@@ -61,8 +62,10 @@ module Strict
 
     def violations(value, configuration = Strict.configuration)
       return Validation::NONE unless configuration.validate?
+      return validator.violations(value) if @detailed_validator
+      return Validation::NONE if validator === value
 
-      Validation.violations(validator, value)
+      Validation.invalid(validator, value)
     end
   end
 end

--- a/lib/strict/declaration.rb
+++ b/lib/strict/declaration.rb
@@ -56,9 +56,13 @@ module Strict
     end
 
     def valid?(value, configuration = Strict.configuration)
-      return true unless configuration.validate?
+      violations(value, configuration).empty?
+    end
 
-      validator === value
+    def violations(value, configuration = Strict.configuration, path: Validation::ROOT_PATH)
+      return Validation::NONE unless configuration.validate?
+
+      Validation.violations(validator, value, path: path)
     end
   end
 end

--- a/lib/strict/declaration.rb
+++ b/lib/strict/declaration.rb
@@ -59,10 +59,10 @@ module Strict
       violations(value, configuration).empty?
     end
 
-    def violations(value, configuration = Strict.configuration, path: Validation::ROOT_PATH)
+    def violations(value, configuration = Strict.configuration)
       return Validation::NONE unless configuration.validate?
 
-      Validation.violations(validator, value, path: path)
+      Validation.violations(validator, value)
     end
   end
 end

--- a/lib/strict/detailed_validator.rb
+++ b/lib/strict/detailed_validator.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Strict
+  module DetailedValidator
+    def ===(value)
+      violations(value).empty?
+    end
+  end
+end

--- a/lib/strict/error.rb
+++ b/lib/strict/error.rb
@@ -2,5 +2,11 @@
 
 module Strict
   class Error < StandardError
+    attr_reader :violations
+
+    def initialize(message = nil, violations: Validation::NONE)
+      @violations = violations.freeze
+      super(message)
+    end
   end
 end

--- a/lib/strict/initialization_error.rb
+++ b/lib/strict/initialization_error.rb
@@ -4,20 +4,29 @@ module Strict
   class InitializationError < Error
     attr_reader :remaining_attributes, :invalid_attributes, :missing_attributes
 
-    def initialize(initializable_class:, remaining_attributes:, invalid_attributes:, missing_attributes:) # rubocop:disable Metrics/MethodLength
+    # rubocop:disable Metrics/MethodLength
+    def initialize(
+      initializable_class:,
+      remaining_attributes:,
+      invalid_attributes:,
+      missing_attributes:,
+      violations: Validation::NONE
+    )
       super(
         message_from(
           initializable_class: initializable_class,
           remaining_attributes: remaining_attributes,
           invalid_attributes: invalid_attributes,
           missing_attributes: missing_attributes
-        )
+        ),
+        violations: violations
       )
 
       @remaining_attributes = remaining_attributes
       @invalid_attributes = invalid_attributes
       @missing_attributes = missing_attributes
     end
+    # rubocop:enable Metrics/MethodLength
 
     private
 

--- a/lib/strict/method_call_error.rb
+++ b/lib/strict/method_call_error.rb
@@ -4,7 +4,15 @@ module Strict
   class MethodCallError < Error
     attr_reader :verifiable_method, :remaining_args, :remaining_kwargs, :invalid_parameters, :missing_parameters
 
-    def initialize(verifiable_method:, remaining_args:, remaining_kwargs:, invalid_parameters:, missing_parameters:) # rubocop:disable Metrics/MethodLength
+    # rubocop:disable Metrics/MethodLength, Metrics/ParameterLists
+    def initialize(
+      verifiable_method:,
+      remaining_args:,
+      remaining_kwargs:,
+      invalid_parameters:,
+      missing_parameters:,
+      violations: Validation::NONE
+    )
       super(
         message_from(
           verifiable_method: verifiable_method,
@@ -12,7 +20,8 @@ module Strict
           remaining_kwargs: remaining_kwargs,
           invalid_parameters: invalid_parameters,
           missing_parameters: missing_parameters
-        )
+        ),
+        violations: violations
       )
 
       @verifiable_method = verifiable_method
@@ -21,6 +30,7 @@ module Strict
       @invalid_parameters = invalid_parameters
       @missing_parameters = missing_parameters
     end
+    # rubocop:enable Metrics/MethodLength, Metrics/ParameterLists
 
     private
 

--- a/lib/strict/method_return_error.rb
+++ b/lib/strict/method_return_error.rb
@@ -4,8 +4,8 @@ module Strict
   class MethodReturnError < Error
     attr_reader :verifiable_method, :value
 
-    def initialize(verifiable_method:, value:)
-      super(message_from(verifiable_method: verifiable_method, value: value))
+    def initialize(verifiable_method:, value:, violations: Validation::NONE)
+      super(message_from(verifiable_method: verifiable_method, value: value), violations: violations)
 
       @verifiable_method = verifiable_method
       @value = value

--- a/lib/strict/methods/verifiable_method.rb
+++ b/lib/strict/methods/verifiable_method.rb
@@ -90,6 +90,7 @@ module Strict
       def verify_parameters!(args, kwargs, configuration)
         invalid_parameters = nil
         missing_parameters = nil
+        violations = nil
         verified_args = nil
         verified_kwargs = nil
         positional_argument_count = args.length
@@ -134,6 +135,8 @@ module Strict
           elsif original_value.equal?(NOT_PROVIDED)
             missing_parameters ||= []
             missing_parameters << parameter.name
+            violations ||= []
+            violations << Validation.missing(parameter.validator, path: [parameter.name])
             next
           else
             value = original_value
@@ -142,7 +145,8 @@ module Strict
 
           value = parameter.coerce(value)
           changed ||= !value.equal?(original_value)
-          if parameter.valid?(value, configuration)
+          parameter_violations = parameter.violations(value, configuration)
+          if parameter_violations.empty?
             case binding.kind
             when :positional, :optional_positional
               if verified_args
@@ -171,6 +175,8 @@ module Strict
           else
             invalid_parameters ||= {}
             invalid_parameters[parameter] = value
+            violations ||= []
+            violations.concat(Validation.prepend_path(parameter_violations, parameter.name))
           end
         end
 
@@ -181,21 +187,32 @@ module Strict
           return [verified_args || args, verified_kwargs || kwargs]
         end
 
+        remaining_args = args.slice(positional_index, positional_argument_count - positional_index) || []
+        remaining_kwargs = remaining_kwargs_from(kwargs)
+        violations ||= []
+        remaining_args.each_with_index do |argument, offset|
+          violations << Validation.unexpected(argument, path: [positional_index + offset])
+        end
+        remaining_kwargs.each do |name, value|
+          violations << Validation.unexpected(value, path: [name])
+        end
         raise Strict::MethodCallError.new(
           verifiable_method: self,
-          remaining_args: args.slice(positional_index, positional_argument_count - positional_index) || [],
-          remaining_kwargs: remaining_kwargs_from(kwargs),
+          remaining_args: remaining_args,
+          remaining_kwargs: remaining_kwargs,
           invalid_parameters: invalid_parameters,
-          missing_parameters: missing_parameters
+          missing_parameters: missing_parameters,
+          violations: violations
         )
       end
       # rubocop:enable Metrics/AbcSize, Metrics/BlockLength, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
 
       def verify_returns!(value, configuration)
         value = returns.coerce(value)
-        return if returns.valid?(value, configuration)
+        violations = returns.violations(value, configuration)
+        return if violations.empty?
 
-        raise Strict::MethodReturnError.new(verifiable_method: self, value: value)
+        raise Strict::MethodReturnError.new(verifiable_method: self, value: value, violations: violations)
       end
 
       private

--- a/lib/strict/return.rb
+++ b/lib/strict/return.rb
@@ -16,9 +16,13 @@ module Strict
     end
 
     def valid?(value, configuration = Strict.configuration)
-      return true unless configuration.validate?
+      violations(value, configuration).empty?
+    end
 
-      validator === value
+    def violations(value, configuration = Strict.configuration)
+      return Validation::NONE unless configuration.validate?
+
+      Validation.violations(validator, value)
     end
 
     def coerce(value)

--- a/lib/strict/return.rb
+++ b/lib/strict/return.rb
@@ -13,6 +13,7 @@ module Strict
     def initialize(validator:, coercer:)
       @validator = validator
       @coercer = coercer
+      @detailed_validator = DetailedValidator === validator
     end
 
     def valid?(value, configuration = Strict.configuration)
@@ -21,8 +22,10 @@ module Strict
 
     def violations(value, configuration = Strict.configuration)
       return Validation::NONE unless configuration.validate?
+      return validator.violations(value) if @detailed_validator
+      return Validation::NONE if validator === value
 
-      Validation.violations(validator, value)
+      Validation.invalid(validator, value)
     end
 
     def coerce(value)

--- a/lib/strict/validation.rb
+++ b/lib/strict/validation.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Strict
+  module Validation
+    NONE = [].freeze
+    ROOT_PATH = [].freeze
+
+    module_function
+
+    def violations(validator, value, path: ROOT_PATH)
+      return validator.__strict_violations__(value, path: path) if validator.respond_to?(:__strict_violations__)
+      return NONE if validator === value
+
+      invalid(validator, value, path: path)
+    end
+
+    def invalid(validator, value, path: ROOT_PATH)
+      [Violation.new(path: path, code: :invalid, value: value, validator: validator)]
+    end
+  end
+end

--- a/lib/strict/validation.rb
+++ b/lib/strict/validation.rb
@@ -7,15 +7,34 @@ module Strict
 
     module_function
 
-    def violations(validator, value, path: ROOT_PATH)
-      return validator.__strict_violations__(value, path: path) if validator.respond_to?(:__strict_violations__)
+    def violations(validator, value)
+      return validator.__strict_violations__(value) if validator.respond_to?(:__strict_violations__)
       return NONE if validator === value
 
-      invalid(validator, value, path: path)
+      invalid(validator, value)
     end
 
-    def invalid(validator, value, path: ROOT_PATH)
-      [Violation.new(path: path, code: :invalid, value: value, validator: validator)]
+    def invalid(validator, value)
+      [Violation.new(path: ROOT_PATH, code: :invalid, value: value, validator: validator)]
+    end
+
+    def missing(validator, path:)
+      Violation.new(path: path, code: :missing, value: nil, validator: validator)
+    end
+
+    def unexpected(value, path:)
+      Violation.new(path: path, code: :unexpected, value: value, validator: nil)
+    end
+
+    def prepend_path(violations, *segments)
+      violations.map do |violation|
+        Violation.new(
+          path: segments + violation.path,
+          code: violation.code,
+          value: violation.value,
+          validator: violation.validator
+        )
+      end
     end
   end
 end

--- a/lib/strict/validation.rb
+++ b/lib/strict/validation.rb
@@ -8,7 +8,7 @@ module Strict
     module_function
 
     def violations(validator, value)
-      return validator.__strict_violations__(value) if validator.respond_to?(:__strict_violations__)
+      return validator.violations(value) if DetailedValidator === validator
       return NONE if validator === value
 
       invalid(validator, value)

--- a/lib/strict/validators/all_of.rb
+++ b/lib/strict/validators/all_of.rb
@@ -3,17 +3,15 @@
 module Strict
   module Validators
     class AllOf
+      include DetailedValidator
+
       attr_reader :subvalidators
 
       def initialize(*subvalidators)
         @subvalidators = subvalidators
       end
 
-      def ===(value)
-        __strict_violations__(value).empty?
-      end
-
-      def __strict_violations__(value)
+      def violations(value)
         violations = nil
         subvalidators.each do |subvalidator|
           subvalidator_violations = Validation.violations(subvalidator, value)

--- a/lib/strict/validators/all_of.rb
+++ b/lib/strict/validators/all_of.rb
@@ -10,9 +10,19 @@ module Strict
       end
 
       def ===(value)
-        subvalidators.all? do |subvalidator|
-          subvalidator === value
+        __strict_violations__(value).empty?
+      end
+
+      def __strict_violations__(value)
+        violations = nil
+        subvalidators.each do |subvalidator|
+          subvalidator_violations = Validation.violations(subvalidator, value)
+          next if subvalidator_violations.empty?
+
+          violations ||= []
+          violations.concat(subvalidator_violations)
         end
+        violations || Validation::NONE
       end
 
       def inspect

--- a/lib/strict/validators/array_of.rb
+++ b/lib/strict/validators/array_of.rb
@@ -3,17 +3,15 @@
 module Strict
   module Validators
     class ArrayOf
+      include DetailedValidator
+
       attr_reader :element_validator
 
       def initialize(element_validator)
         @element_validator = element_validator
       end
 
-      def ===(value)
-        __strict_violations__(value).empty?
-      end
-
-      def __strict_violations__(value)
+      def violations(value)
         return Validation.invalid(self, value) unless Array === value
 
         violations = nil

--- a/lib/strict/validators/array_of.rb
+++ b/lib/strict/validators/array_of.rb
@@ -10,9 +10,21 @@ module Strict
       end
 
       def ===(value)
-        Array === value && value.all? do |v|
-          element_validator === v
+        __strict_violations__(value).empty?
+      end
+
+      def __strict_violations__(value)
+        return Validation.invalid(self, value) unless Array === value
+
+        violations = nil
+        value.each_with_index do |element, index|
+          element_violations = Validation.violations(element_validator, element)
+          next if element_violations.empty?
+
+          violations ||= []
+          violations.concat(Validation.prepend_path(element_violations, index))
         end
+        violations || Validation::NONE
       end
 
       def inspect

--- a/lib/strict/validators/hash_of.rb
+++ b/lib/strict/validators/hash_of.rb
@@ -3,6 +3,8 @@
 module Strict
   module Validators
     class HashOf
+      include DetailedValidator
+
       attr_reader :key_validator, :value_validator
 
       def initialize(key_validator, value_validator)
@@ -10,12 +12,8 @@ module Strict
         @value_validator = value_validator
       end
 
-      def ===(value)
-        __strict_violations__(value).empty?
-      end
-
       # rubocop:disable Metrics/MethodLength
-      def __strict_violations__(value)
+      def violations(value)
         return Validation.invalid(self, value) unless Hash === value
 
         violations = nil

--- a/lib/strict/validators/hash_of.rb
+++ b/lib/strict/validators/hash_of.rb
@@ -11,10 +11,26 @@ module Strict
       end
 
       def ===(value)
-        Hash === value && value.all? do |k, v|
-          key_validator === k && value_validator === v
-        end
+        __strict_violations__(value).empty?
       end
+
+      # rubocop:disable Metrics/MethodLength
+      def __strict_violations__(value)
+        return Validation.invalid(self, value) unless Hash === value
+
+        violations = nil
+        value.each do |key, entry_value|
+          key_violations = Validation.violations(key_validator, key)
+          value_violations = Validation.violations(value_validator, entry_value)
+          next if key_violations.empty? && value_violations.empty?
+
+          violations ||= []
+          violations.concat(Validation.prepend_path(key_violations, key))
+          violations.concat(Validation.prepend_path(value_violations, key))
+        end
+        violations || Validation::NONE
+      end
+      # rubocop:enable Metrics/MethodLength
 
       def inspect
         "HashOf(#{key_validator.inspect} => #{value_validator.inspect})"

--- a/lib/strict/violation.rb
+++ b/lib/strict/violation.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Strict
+  Violation = Data.define(:path, :code, :value, :validator) do
+    def initialize(path:, code:, value:, validator:)
+      super(path: path.dup.freeze, code: code, value: value, validator: validator)
+    end
+  end
+end

--- a/sig/strict.rbs
+++ b/sig/strict.rbs
@@ -38,6 +38,7 @@ module Strict
 
   type attribute_coercion = bool | Symbol | _Coercer[untyped, untyped]
   type method_coercion = false | _Coercer[untyped, untyped]
+  type violation_code = :invalid | :missing | :unexpected
 
   interface _AttributesDsl
     include _ValidationDsl
@@ -146,7 +147,15 @@ module Strict
     attr_accessor sample_rate: Numeric
   end
 
+  class Violation
+    def path: () -> Array[untyped]
+    def code: () -> violation_code
+    def value: () -> untyped
+    def validator: () -> _Validator?
+  end
+
   class Error < StandardError
+    def violations: () -> Array[Violation]
   end
 
   class AssignmentError < Error

--- a/sig/strict.rbs
+++ b/sig/strict.rbs
@@ -142,12 +142,23 @@ module Strict
   module Union
   end
 
+  module DetailedValidator
+    def ===: (untyped value) -> bool
+    def violations: (untyped value) -> Array[Violation]
+  end
+
   class Configuration
     attr_accessor random: Random::Formatter
     attr_accessor sample_rate: Numeric
   end
 
   class Violation
+    def initialize: (
+      path: Array[untyped],
+      code: violation_code,
+      value: untyped,
+      validator: _Validator?
+    ) -> void
     def path: () -> Array[untyped]
     def code: () -> violation_code
     def value: () -> untyped

--- a/spec/strict/violation_spec.rb
+++ b/spec/strict/violation_spec.rb
@@ -23,4 +23,118 @@ RSpec.describe Strict::Violation do
       expect(violation.validator).to equal(Integer)
     }
   end
+
+  it "describes structural and nested initialization failures" do
+    value_class = Class.new do
+      include Strict::Value
+
+      attributes do
+        name String
+        scores ArrayOf(Integer)
+        groups HashOf(Symbol => ArrayOf(String))
+      end
+    end
+
+    expect do
+      value_class.new(
+        scores: [1, "two"],
+        groups: { "admins" => ["one"], members: ["two", 3] },
+        extra: true
+      )
+    end.to raise_error(Strict::InitializationError) { |error|
+      expect(error.violations.map { |violation|
+        [violation.path, violation.code, violation.value, violation.validator]
+      }).to contain_exactly(
+        [[:name], :missing, nil, String],
+        [[:scores, 1], :invalid, "two", Integer],
+        [[:groups, "admins"], :invalid, "admins", Symbol],
+        [[:groups, :members, 1], :invalid, 3, String],
+        [[:extra], :unexpected, true, nil]
+      )
+    }
+  end
+
+  it "describes invalid, missing, and unexpected method arguments" do
+    method_class = Class.new do
+      include Strict::Method
+
+      sig do
+        items ArrayOf(Integer)
+        required String
+      end
+      def call(items, required:); end
+    end
+
+    expect do
+      method_class.new.call([1, "two"], :extra, unexpected: true)
+    end.to raise_error(Strict::MethodCallError) { |error|
+      expect(error.violations.map { |violation|
+        [violation.path, violation.code, violation.value, violation.validator]
+      }).to contain_exactly(
+        [[:items, 1], :invalid, "two", Integer],
+        [[:required], :missing, nil, String],
+        [[1], :unexpected, :extra, nil],
+        [[:unexpected], :unexpected, true, nil]
+      )
+    }
+  end
+
+  it "describes an invalid method return from its root path" do
+    method_class = Class.new do
+      include Strict::Method
+
+      sig { returns ArrayOf(String) }
+      def call = ["one", 2]
+    end
+
+    expect do
+      method_class.new.call
+    end.to raise_error(Strict::MethodReturnError) { |error|
+      violation = error.violations.fetch(0)
+
+      expect(violation.path).to eq([1])
+      expect(violation.code).to eq(:invalid)
+      expect(violation.value).to eq(2)
+      expect(violation.validator).to equal(String)
+    }
+  end
+
+  it "preserves nested paths through composed validators" do
+    value_class = Class.new do
+      include Strict::Value
+
+      attributes { items AllOf(Array, ArrayOf(Integer)) }
+    end
+
+    expect do
+      value_class.new(items: [1, "two"])
+    end.to raise_error(Strict::InitializationError) { |error|
+      violation = error.violations.fetch(0)
+
+      expect(violation.path).to eq([:items, 1])
+      expect(violation.value).to eq("two")
+      expect(violation.validator).to equal(Integer)
+    }
+  end
+
+  it "supports validators that only implement case equality" do
+    validated_values = []
+    validator = Object.new
+    validator.define_singleton_method(:===) do |value|
+      validated_values << value
+      false
+    end
+    value_class = Class.new do
+      include Strict::Value
+
+      attributes { value validator }
+    end
+
+    expect do
+      value_class.new(value: :invalid)
+    end.to raise_error(Strict::InitializationError) { |error|
+      expect(error.violations.fetch(0).validator).to equal(validator)
+    }
+    expect(validated_values).to eq([:invalid])
+  end
 end

--- a/spec/strict/violation_spec.rb
+++ b/spec/strict/violation_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Strict::Violation do
+  it "describes an invalid assignment" do
+    object_class = Class.new do
+      include Strict::Object
+
+      attributes { count Integer }
+    end
+    object = object_class.new(count: 1)
+
+    expect do
+      object.count = "one"
+    end.to raise_error(Strict::AssignmentError) { |error|
+      violation = error.violations.fetch(0)
+
+      expect(violation).to be_a(described_class)
+      expect(violation.path).to eq([:count])
+      expect(violation.code).to eq(:invalid)
+      expect(violation.value).to eq("one")
+      expect(violation.validator).to equal(Integer)
+    }
+  end
+end

--- a/spec/strict/violation_spec.rb
+++ b/spec/strict/violation_spec.rb
@@ -137,4 +137,54 @@ RSpec.describe Strict::Violation do
     }
     expect(validated_values).to eq([:invalid])
   end
+
+  it "accepts static values as validators" do
+    value_class = Class.new do
+      include Strict::Value
+
+      attributes { state "ready" }
+    end
+
+    expect do
+      value_class.new(state: "pending")
+    end.to raise_error(Strict::InitializationError) { |error|
+      violation = error.violations.fetch(0)
+
+      expect(violation.path).to eq([:state])
+      expect(violation.value).to eq("pending")
+      expect(violation.validator).to eq("ready")
+    }
+  end
+
+  it "prefixes relative paths from an opt-in detailed validator" do
+    email_validator = Class.new do
+      include Strict::DetailedValidator
+
+      def violations(value)
+        value.each_with_index.filter_map do |email, index|
+          next if String === email
+
+          Strict::Violation.new(path: [index], code: :invalid, value: email, validator: String)
+        end
+      end
+    end.new
+    value_class = Class.new do
+      include Strict::Value
+
+      attributes { emails email_validator }
+    end
+
+    expect(email_validator === ["one@example.com"]).to be(true)
+    expect(value_class.new(emails: ["one@example.com"]).to_h).to eq(emails: ["one@example.com"])
+    expect do
+      value_class.new(emails: ["one@example.com", 2])
+    end.to raise_error(Strict::InitializationError) { |error|
+      violation = error.violations.fetch(0)
+
+      expect(violation.path).to eq([:emails, 1])
+      expect(violation.code).to eq(:invalid)
+      expect(violation.value).to eq(2)
+      expect(violation.validator).to equal(String)
+    }
+  end
 end


### PR DESCRIPTION
## Summary

- expose structured `Strict::Violation` records from validation errors
- preserve relative paths through attributes, parameters, returns, and built-in collection validators
- report invalid, missing, and unexpected values without exposing internal descriptors
- add optional `Strict::DetailedValidator` support for custom nested failures while retaining the existing `===` validator protocol
- document and type the public contract

## Compatibility and performance

- classes, modules, literals, and custom validators that only implement `===` remain supported
- successful-path allocation counts are unchanged
- six interleaved benchmark runs were effectively flat overall against `5c23ad8` (−0.4% geometric mean)

## Verification

- `bundle exec rake`
- 266 examples, 0 failures
- RuboCop: no offenses
- RBS validation passed
