### PR TITLE
Add supported RSpec integration

### DIFF
--- a/API.md
+++ b/API.md
@@ -174,6 +174,48 @@ Interface instances expose their `implementation`. The class coercer:
 
 Interface subclassing and re-exposing a method are outside the compatibility boundary.
 
+## RSpec integration
+
+Strict provides opt-in integration with RSpec 3.13. RSpec is not a runtime dependency and `require "strict"` does not
+load it. Applications that use the integration must add RSpec to their test bundle and load the adapter from their spec
+helper:
+
+```ruby
+require "strict/rspec"
+```
+
+Loading the adapter registers the `validate` and `conform_to` matchers and adds `strict_double` to RSpec example groups.
+
+### RSpec matchers
+
+`expect(validator).to validate(value)` applies the ordinary `===` validator protocol. For a
+`Strict::DetailedValidator`, it uses `violations(value)` and includes root or nested violation paths when the expectation
+fails. RSpec matcher objects and compatible instance doubles are accepted as test values. Exact failure-message wording
+and formatting are not fixed.
+
+`expect(implementation).to conform_to(interface)` checks the same public method and required-keyword conformance as
+constructing the interface. It does not invoke exposed methods. A failed expectation includes the conformance error's
+details, without a fixed wording or formatting contract.
+
+### RSpec doubles and matcher placeholders
+
+`strict_double(strict_class, stubs = {})` returns an RSpec instance verifying double. For a `Strict::Interface`, every
+exposed method is stubbed to return `nil` unless `stubs` provides another result. Calls through the interface still
+validate parameters and return values, so an omitted stub can cause `Strict::MethodReturnError` when `nil` is not a valid
+return. For other classes, only the supplied methods are stubbed. RSpec rejects stubs for methods that the doubled class
+does not expose.
+
+RSpec instance verifying doubles created by `strict_double` or `instance_double` satisfy a class or module validator
+when an instance of the doubled class would satisfy it. This applies to attributes, signed parameters, return values,
+and values nested inside `ArrayOf`, `HashOf`, or `AllOf`. Plain, non-verifying doubles do not bypass validation.
+
+RSpec matcher objects can stand in for validated test values at those same locations. When an expected `Strict::Value`
+is used in an RSpec argument expectation, RSpec recursively applies matcher objects in its attributes. The expected and
+actual values must have the same exact class. Loading the adapter does not change `Strict::Value#==`, `#eql?`, or `#hash`.
+
+`Strict::RSpec` is the public integration namespace. Its nested constants, singleton methods, generated RSpec matcher
+classes, RSpec proxy metadata, and reflection details are outside the compatibility boundary.
+
 ## Validators and coercers
 
 Any object that implements `===` can be a validator. This includes classes, modules, literals, and custom validators. When a validator rejects a value, Strict reports that validator in one `:invalid` violation at the current path.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add closed discriminated unions whose generated variants use `Strict::Value` for attributes and value behavior.
 - Add inherited value and object attribute declarations and shared union attributes.
 - Add structured validation violations with paths, codes, rejected values, and validators for assignment, initialization, signed method calls, and returns, plus an optional detailed-validator protocol for custom nested failures.
+- Add opt-in RSpec matchers, verifying doubles, and nested matcher placeholders for Strict values and validations.
 
 ### Breaking changes
 

--- a/README.md
+++ b/README.md
@@ -298,9 +298,18 @@ storage = Storage.new(Storages::Wat.new)
 # => Strict::ImplementationDoesNotConformError
 ```
 
-### Experimental RSpec extensions
+### RSpec extensions
 
-Add RSpec to the test bundle and require the opt-in adapter from the spec helper:
+Strict provides supported, opt-in integration with RSpec 3.13. RSpec remains an optional dependency and is not loaded by
+`require "strict"`. Add RSpec to the test bundle:
+
+```rb
+group :test do
+  gem "rspec", "~> 3.13"
+end
+```
+
+Then require the adapter from the spec helper:
 
 ```rb
 require "strict/rspec"

--- a/README.md
+++ b/README.md
@@ -298,6 +298,63 @@ storage = Storage.new(Storages::Wat.new)
 # => Strict::ImplementationDoesNotConformError
 ```
 
+### Experimental RSpec extensions
+
+Add RSpec to the test bundle and require the opt-in adapter from the spec helper:
+
+```rb
+require "strict/rspec"
+```
+
+The adapter provides matchers for validators and interfaces:
+
+```rb
+expect(String).to validate("value")
+expect(String).not_to validate(1)
+
+expect(Storages::Memory.new).to conform_to(Storage)
+expect(Object.new).not_to conform_to(Storage)
+```
+
+`strict_double` builds an RSpec verifying double. For an interface, it stubs every exposed method to `nil` unless a
+different result is provided, so the double conforms without extra setup:
+
+```rb
+storage = strict_double(Storage, write: true, read: "contents")
+
+expect(storage).to conform_to(Storage)
+Storage.new(storage).read(key: "some/path")
+# => "contents"
+```
+
+RSpec instance doubles also satisfy Strict class validators for attributes, signed parameters, and return values. Plain
+doubles remain invalid:
+
+```rb
+class Item
+  include Strict::Value
+
+  attributes do
+    sku String
+  end
+end
+
+class Shipment
+  include Strict::Value
+
+  attributes do
+    item Item
+  end
+end
+
+item = instance_double(Item, sku: "item_123")
+Shipment.new(item: item)
+# => #<Shipment item=#<InstanceDouble(Item)>>
+
+Shipment.new(item: double("item"))
+# => Strict::InitializationError
+```
+
 ### Configuration
 
 Strict exposes some configuration options which can be configured globally via `Strict.configure { ... }` or overridden

--- a/README.md
+++ b/README.md
@@ -316,6 +316,9 @@ expect(Storages::Memory.new).to conform_to(Storage)
 expect(Object.new).not_to conform_to(Storage)
 ```
 
+When validation fails, `validate` uses `Strict::Violation` records to report root and nested
+`Strict::DetailedValidator` failure paths.
+
 `strict_double` builds an RSpec verifying double. For an interface, it stubs every exposed method to `nil` unless a
 different result is provided, so the double conforms without extra setup:
 

--- a/README.md
+++ b/README.md
@@ -358,8 +358,8 @@ Shipment.new(item: double("item"))
 # => Strict::InitializationError
 ```
 
-Matcher objects can also stand in for validated fields when constructing expected Strict values. RSpec recursively
-applies the nested matchers in argument expectations:
+Matcher objects can also stand in for validated fields or elements of built-in collection validators when constructing
+expected Strict values. RSpec recursively applies the nested matchers in argument expectations:
 
 ```rb
 expect(dispatcher).to have_received(:ship).with(

--- a/README.md
+++ b/README.md
@@ -355,6 +355,19 @@ Shipment.new(item: double("item"))
 # => Strict::InitializationError
 ```
 
+Matcher objects can also stand in for validated fields when constructing expected Strict values. RSpec recursively
+applies the nested matchers in argument expectations:
+
+```rb
+expect(dispatcher).to have_received(:ship).with(
+  shipment: Shipment.new(
+    item: have_attributes(sku: "item_123")
+  )
+)
+```
+
+This composition does not change normal Strict value equality or hashing.
+
 ### Configuration
 
 Strict exposes some configuration options which can be configured globally via `Strict.configure { ... }` or overridden

--- a/lib/strict.rb
+++ b/lib/strict.rb
@@ -2,6 +2,7 @@
 
 require "zeitwerk"
 loader = Zeitwerk::Loader.for_gem
+loader.ignore("#{__dir__}/strict/rspec.rb")
 loader.setup
 
 module Strict

--- a/lib/strict/rspec.rb
+++ b/lib/strict/rspec.rb
@@ -7,7 +7,48 @@ require "rspec/mocks"
 
 module Strict
   module RSpec
+    INSTANCE_VARIABLE_GET = ::Object.instance_method(:instance_variable_get)
+    private_constant :INSTANCE_VARIABLE_GET
+
+    class << self
+      def valid?(validator, value)
+        validator === value || instance_double_valid_for?(validator, value)
+      end
+
+      def instance_double_valid_for?(validator, value)
+        return false unless ::RSpec::Mocks::InstanceVerifyingDouble === value
+        return false unless ::Module === validator
+
+        doubled_module = INSTANCE_VARIABLE_GET.bind_call(value, :@doubled_module).target
+        doubled_module && !!(doubled_module <= validator)
+      end
+
+      def stubs_for(strict_class, stubs)
+        return stubs unless strict_class.respond_to?(:strict_interface_conformance)
+
+        strict_class.strict_instance_methods.to_h { |name, _method| [name, nil] }.merge(stubs)
+      end
+    end
+
+    module ValidatesInstanceDoubles
+      def valid?(value, configuration = Strict.configuration)
+        super || Strict::RSpec.instance_double_valid_for?(validator, value)
+      end
+    end
+
+    module ExampleMethods
+      def strict_double(strict_class, stubs = {})
+        instance_double(strict_class, Strict::RSpec.stubs_for(strict_class, stubs))
+      end
+    end
   end
+end
+
+Strict::Declaration.prepend(Strict::RSpec::ValidatesInstanceDoubles)
+Strict::Return.prepend(Strict::RSpec::ValidatesInstanceDoubles)
+
+RSpec.configure do |config|
+  config.include Strict::RSpec::ExampleMethods
 end
 
 RSpec::Matchers.define :conform_to do |interface|
@@ -31,7 +72,7 @@ end
 
 RSpec::Matchers.define :validate do |value|
   match do |validator|
-    validator === value
+    Strict::RSpec.valid?(validator, value)
   end
 
   failure_message do |validator|

--- a/lib/strict/rspec.rb
+++ b/lib/strict/rspec.rb
@@ -8,74 +8,76 @@ require "rspec/support/fuzzy_matcher"
 
 module Strict
   module RSpec
-    NO_VIOLATIONS = [].freeze
-    INSTANCE_VARIABLE_GET = ::Object.instance_method(:instance_variable_get)
-    private_constant :NO_VIOLATIONS
-    private_constant :INSTANCE_VARIABLE_GET
+    module Support
+      NO_VIOLATIONS = [].freeze
+      INSTANCE_VARIABLE_GET = ::Object.instance_method(:instance_variable_get)
+      private_constant :NO_VIOLATIONS
+      private_constant :INSTANCE_VARIABLE_GET
 
-    class << self
-      def valid?(validator, value)
-        violations(validator, value).empty?
-      end
+      class << self
+        def violations(validator, value)
+          return NO_VIOLATIONS if test_value?(validator, value)
+          return validator.violations(value) if Strict::DetailedValidator === validator
+          return NO_VIOLATIONS if validator === value
 
-      def violations(validator, value)
-        return NO_VIOLATIONS if test_value?(validator, value)
-        return validator.violations(value) if Strict::DetailedValidator === validator
-        return NO_VIOLATIONS if validator === value
-
-        [Strict::Violation.new(path: [], code: :invalid, value: value, validator: validator)]
-      end
-
-      def test_value?(validator, value)
-        matcher?(value) || instance_double_valid_for?(validator, value)
-      end
-
-      def matcher?(value)
-        ::RSpec::Support.is_a_matcher?(value)
-      end
-
-      def instance_double_valid_for?(validator, value)
-        return false unless ::RSpec::Mocks::InstanceVerifyingDouble === value
-        return false unless ::Module === validator
-
-        doubled_module = INSTANCE_VARIABLE_GET.bind_call(value, :@doubled_module).target
-        doubled_module && !!(doubled_module <= validator)
-      end
-
-      def stubs_for(strict_class, stubs)
-        return stubs unless strict_class.respond_to?(:strict_interface_conformance)
-
-        strict_class.strict_instance_methods.to_h { |name, _method| [name, nil] }.merge(stubs)
-      end
-
-      def violation_details(violations)
-        descriptions = violations.map { |violation| "  - #{violation_description(violation)}" }
-        "violations:\n#{descriptions.join("\n")}"
-      end
-
-      private
-
-      def violation_description(violation)
-        location = violation.path.empty? ? "root" : violation.path.inspect
-
-        case violation.code
-        when :invalid
-          "at #{location}: expected #{format(violation.validator)}, got #{format(violation.value)}"
-        when :missing
-          "at #{location}: expected #{format(violation.validator)}, but the value was missing"
-        when :unexpected
-          "at #{location}: got unexpected #{format(violation.value)}"
+          [Strict::Violation.new(path: [], code: :invalid, value: value, validator: validator)]
         end
-      end
 
-      def format(value)
-        ::RSpec::Support::ObjectFormatter.format(value)
+        def test_value?(validator, value)
+          matcher?(value) || instance_double_valid_for?(validator, value)
+        end
+
+        def no_violations
+          NO_VIOLATIONS
+        end
+
+        def stubs_for(strict_class, stubs)
+          return stubs unless strict_class.respond_to?(:strict_interface_conformance)
+
+          strict_class.strict_instance_methods.to_h { |name, _method| [name, nil] }.merge(stubs)
+        end
+
+        def violation_details(violations)
+          descriptions = violations.map { |violation| "  - #{violation_description(violation)}" }
+          "violations:\n#{descriptions.join("\n")}"
+        end
+
+        private
+
+        def matcher?(value)
+          ::RSpec::Support.is_a_matcher?(value)
+        end
+
+        def instance_double_valid_for?(validator, value)
+          return false unless ::RSpec::Mocks::InstanceVerifyingDouble === value
+          return false unless ::Module === validator
+
+          doubled_module = INSTANCE_VARIABLE_GET.bind_call(value, :@doubled_module).target
+          doubled_module && !!(doubled_module <= validator)
+        end
+
+        def violation_description(violation)
+          location = violation.path.empty? ? "root" : violation.path.inspect
+
+          case violation.code
+          when :invalid
+            "at #{location}: expected #{format(violation.validator)}, got #{format(violation.value)}"
+          when :missing
+            "at #{location}: expected #{format(violation.validator)}, but the value was missing"
+          when :unexpected
+            "at #{location}: got unexpected #{format(violation.value)}"
+          end
+        end
+
+        def format(value)
+          ::RSpec::Support::ObjectFormatter.format(value)
+        end
       end
     end
 
     module AcceptsMatchersAndDoubles
       def violations(value, configuration = Strict.configuration)
-        return NO_VIOLATIONS if Strict::RSpec.test_value?(validator, value)
+        return Support.no_violations if Support.test_value?(validator, value)
 
         super
       end
@@ -83,7 +85,7 @@ module Strict
 
     module AcceptsNestedMatchersAndDoubles
       def violations(validator, value)
-        return NO_VIOLATIONS if Strict::RSpec.test_value?(validator, value)
+        return Support.no_violations if Support.test_value?(validator, value)
 
         super
       end
@@ -103,52 +105,55 @@ module Strict
 
     module ExampleMethods
       def strict_double(strict_class, stubs = {})
-        instance_double(strict_class, Strict::RSpec.stubs_for(strict_class, stubs))
+        instance_double(strict_class, Support.stubs_for(strict_class, stubs))
       end
     end
-  end
-end
 
-Strict::Declaration.prepend(Strict::RSpec::AcceptsMatchersAndDoubles)
-Strict::Return.prepend(Strict::RSpec::AcceptsMatchersAndDoubles)
-Strict::Validation.singleton_class.prepend(Strict::RSpec::AcceptsNestedMatchersAndDoubles)
-Strict::Value.prepend(Strict::RSpec::ComposableValue)
+    Strict::Declaration.prepend(AcceptsMatchersAndDoubles)
+    Strict::Return.prepend(AcceptsMatchersAndDoubles)
+    Strict::Validation.singleton_class.prepend(AcceptsNestedMatchersAndDoubles)
+    Strict::Value.prepend(ComposableValue)
 
-RSpec.configure do |config|
-  config.include Strict::RSpec::ExampleMethods
-end
+    ::RSpec.configure do |config|
+      config.include ExampleMethods
+    end
 
-RSpec::Matchers.define :conform_to do |interface|
-  match do |implementation|
-    @conformance_error = nil
-    interface.new(implementation)
-    true
-  rescue Strict::ImplementationDoesNotConformError => e
-    @conformance_error = e
-    false
-  end
+    ::RSpec::Matchers.define :conform_to do |interface|
+      match do |implementation|
+        @conformance_error = nil
+        interface.new(implementation)
+        true
+      rescue Strict::ImplementationDoesNotConformError => e
+        @conformance_error = e
+        false
+      end
 
-  failure_message do |implementation|
-    "expected #{implementation.inspect} to conform to #{interface.inspect}\n\n#{@conformance_error.message}"
-  end
+      failure_message do |implementation|
+        "expected #{implementation.inspect} to conform to #{interface.inspect}\n\n#{@conformance_error.message}"
+      end
 
-  failure_message_when_negated do |implementation|
-    "expected #{implementation.inspect} not to conform to #{interface.inspect}"
-  end
-end
+      failure_message_when_negated do |implementation|
+        "expected #{implementation.inspect} not to conform to #{interface.inspect}"
+      end
+    end
 
-RSpec::Matchers.define :validate do |value|
-  match do |validator|
-    @violations = Strict::RSpec.violations(validator, value)
-    @violations.empty?
-  end
+    ::RSpec::Matchers.define :validate do |value|
+      match do |validator|
+        @violations = Support.violations(validator, value)
+        @violations.empty?
+      end
 
-  failure_message do |validator|
-    message = "expected #{validator.inspect} to validate #{value.inspect}"
-    "#{message}\n\n#{Strict::RSpec.violation_details(@violations)}"
-  end
+      failure_message do |validator|
+        message = "expected #{validator.inspect} to validate #{value.inspect}"
+        "#{message}\n\n#{Support.violation_details(@violations)}"
+      end
 
-  failure_message_when_negated do |validator|
-    "expected #{validator.inspect} not to validate #{value.inspect}"
+      failure_message_when_negated do |validator|
+        "expected #{validator.inspect} not to validate #{value.inspect}"
+      end
+    end
+
+    private_constant :Support, :AcceptsMatchersAndDoubles, :AcceptsNestedMatchersAndDoubles, :ComposableValue,
+                     :ExampleMethods
   end
 end

--- a/lib/strict/rspec.rb
+++ b/lib/strict/rspec.rb
@@ -8,12 +8,26 @@ require "rspec/support/fuzzy_matcher"
 
 module Strict
   module RSpec
+    NO_VIOLATIONS = [].freeze
     INSTANCE_VARIABLE_GET = ::Object.instance_method(:instance_variable_get)
+    private_constant :NO_VIOLATIONS
     private_constant :INSTANCE_VARIABLE_GET
 
     class << self
       def valid?(validator, value)
-        validator === value || matcher?(value) || instance_double_valid_for?(validator, value)
+        violations(validator, value).empty?
+      end
+
+      def violations(validator, value)
+        return NO_VIOLATIONS if test_value?(validator, value)
+        return validator.violations(value) if Strict::DetailedValidator === validator
+        return NO_VIOLATIONS if validator === value
+
+        [Strict::Violation.new(path: [], code: :invalid, value: value, validator: validator)]
+      end
+
+      def test_value?(validator, value)
+        matcher?(value) || instance_double_valid_for?(validator, value)
       end
 
       def matcher?(value)
@@ -33,11 +47,37 @@ module Strict
 
         strict_class.strict_instance_methods.to_h { |name, _method| [name, nil] }.merge(stubs)
       end
+
+      def violation_details(violations)
+        descriptions = violations.map { |violation| "  - #{violation_description(violation)}" }
+        "violations:\n#{descriptions.join("\n")}"
+      end
+
+      private
+
+      def violation_description(violation)
+        location = violation.path.empty? ? "root" : violation.path.inspect
+
+        case violation.code
+        when :invalid
+          "at #{location}: expected #{format(violation.validator)}, got #{format(violation.value)}"
+        when :missing
+          "at #{location}: expected #{format(violation.validator)}, but the value was missing"
+        when :unexpected
+          "at #{location}: got unexpected #{format(violation.value)}"
+        end
+      end
+
+      def format(value)
+        ::RSpec::Support::ObjectFormatter.format(value)
+      end
     end
 
     module AcceptsMatchersAndDoubles
-      def valid?(value, configuration = Strict.configuration)
-        super || Strict::RSpec.matcher?(value) || Strict::RSpec.instance_double_valid_for?(validator, value)
+      def violations(value, configuration = Strict.configuration)
+        return NO_VIOLATIONS if Strict::RSpec.test_value?(validator, value)
+
+        super
       end
     end
 
@@ -90,11 +130,13 @@ end
 
 RSpec::Matchers.define :validate do |value|
   match do |validator|
-    Strict::RSpec.valid?(validator, value)
+    @violations = Strict::RSpec.violations(validator, value)
+    @violations.empty?
   end
 
   failure_message do |validator|
-    "expected #{validator.inspect} to validate #{value.inspect}"
+    message = "expected #{validator.inspect} to validate #{value.inspect}"
+    "#{message}\n\n#{Strict::RSpec.violation_details(@violations)}"
   end
 
   failure_message_when_negated do |validator|

--- a/lib/strict/rspec.rb
+++ b/lib/strict/rspec.rb
@@ -81,6 +81,14 @@ module Strict
       end
     end
 
+    module AcceptsNestedMatchersAndDoubles
+      def violations(validator, value)
+        return NO_VIOLATIONS if Strict::RSpec.test_value?(validator, value)
+
+        super
+      end
+    end
+
     module ComposableValue
       def ===(other)
         return false unless other.instance_of?(self.class)
@@ -103,6 +111,7 @@ end
 
 Strict::Declaration.prepend(Strict::RSpec::AcceptsMatchersAndDoubles)
 Strict::Return.prepend(Strict::RSpec::AcceptsMatchersAndDoubles)
+Strict::Validation.singleton_class.prepend(Strict::RSpec::AcceptsNestedMatchersAndDoubles)
 Strict::Value.prepend(Strict::RSpec::ComposableValue)
 
 RSpec.configure do |config|

--- a/lib/strict/rspec.rb
+++ b/lib/strict/rspec.rb
@@ -4,6 +4,7 @@ require "strict"
 require "rspec/core"
 require "rspec/expectations"
 require "rspec/mocks"
+require "rspec/support/fuzzy_matcher"
 
 module Strict
   module RSpec
@@ -12,7 +13,11 @@ module Strict
 
     class << self
       def valid?(validator, value)
-        validator === value || instance_double_valid_for?(validator, value)
+        validator === value || matcher?(value) || instance_double_valid_for?(validator, value)
+      end
+
+      def matcher?(value)
+        ::RSpec::Support.is_a_matcher?(value)
       end
 
       def instance_double_valid_for?(validator, value)
@@ -30,9 +35,21 @@ module Strict
       end
     end
 
-    module ValidatesInstanceDoubles
+    module AcceptsMatchersAndDoubles
       def valid?(value, configuration = Strict.configuration)
-        super || Strict::RSpec.instance_double_valid_for?(validator, value)
+        super || Strict::RSpec.matcher?(value) || Strict::RSpec.instance_double_valid_for?(validator, value)
+      end
+    end
+
+    module ComposableValue
+      def ===(other)
+        return false unless other.instance_of?(self.class)
+
+        self.class.strict_attributes.all? do |attribute|
+          expected = public_send(attribute.name)
+          actual = other.public_send(attribute.name)
+          ::RSpec::Support::FuzzyMatcher.values_match?(expected, actual)
+        end
       end
     end
 
@@ -44,8 +61,9 @@ module Strict
   end
 end
 
-Strict::Declaration.prepend(Strict::RSpec::ValidatesInstanceDoubles)
-Strict::Return.prepend(Strict::RSpec::ValidatesInstanceDoubles)
+Strict::Declaration.prepend(Strict::RSpec::AcceptsMatchersAndDoubles)
+Strict::Return.prepend(Strict::RSpec::AcceptsMatchersAndDoubles)
+Strict::Value.prepend(Strict::RSpec::ComposableValue)
 
 RSpec.configure do |config|
   config.include Strict::RSpec::ExampleMethods

--- a/lib/strict/rspec.rb
+++ b/lib/strict/rspec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "strict"
+require "rspec/core"
+require "rspec/expectations"
+require "rspec/mocks"
+
+module Strict
+  module RSpec
+  end
+end
+
+RSpec::Matchers.define :conform_to do |interface|
+  match do |implementation|
+    @conformance_error = nil
+    interface.new(implementation)
+    true
+  rescue Strict::ImplementationDoesNotConformError => e
+    @conformance_error = e
+    false
+  end
+
+  failure_message do |implementation|
+    "expected #{implementation.inspect} to conform to #{interface.inspect}\n\n#{@conformance_error.message}"
+  end
+
+  failure_message_when_negated do |implementation|
+    "expected #{implementation.inspect} not to conform to #{interface.inspect}"
+  end
+end
+
+RSpec::Matchers.define :validate do |value|
+  match do |validator|
+    validator === value
+  end
+
+  failure_message do |validator|
+    "expected #{validator.inspect} to validate #{value.inspect}"
+  end
+
+  failure_message_when_negated do |validator|
+    "expected #{validator.inspect} not to validate #{value.inspect}"
+  end
+end

--- a/sig/strict/rspec.rbs
+++ b/sig/strict/rspec.rbs
@@ -1,0 +1,10 @@
+module Strict
+  # Extend this type-only interface in application test signatures for RSpec
+  # example contexts that load strict/rspec.
+  interface _RSpecExampleMethods
+    def strict_double: (Module strict_class, ?Hash[Symbol, untyped] stubs) -> untyped
+  end
+
+  module RSpec
+  end
+end

--- a/spec/strict/rspec_spec.rb
+++ b/spec/strict/rspec_spec.rb
@@ -13,19 +13,31 @@ RSpec.describe Strict::RSpec do
 
         attributes do
           other_value nested_validator
+          other_values ArrayOf(nested_validator)
         end
       end
       receiver_class = Class.new do
         def bar(value:); end
       end
       receiver = instance_spy(receiver_class)
-      receiver.bar(value: value_class.new(other_value: nested_value_class.new(1)))
+      receiver.bar(
+        value: value_class.new(
+          other_value: nested_value_class.new(1),
+          other_values: [nested_value_class.new(2)]
+        )
+      )
 
       expect(receiver).to have_received(:bar).with(
-        value: value_class.new(other_value: have_attributes(a: 1))
+        value: value_class.new(
+          other_value: have_attributes(a: 1),
+          other_values: [have_attributes(a: 2)]
+        )
       )
       expect(receiver).not_to have_received(:bar).with(
-        value: value_class.new(other_value: have_attributes(a: 2))
+        value: value_class.new(
+          other_value: have_attributes(a: 2),
+          other_values: [have_attributes(a: 3)]
+        )
       )
     end
   end

--- a/spec/strict/rspec_spec.rb
+++ b/spec/strict/rspec_spec.rb
@@ -133,7 +133,11 @@ RSpec.describe Strict::RSpec do
 
       expect do
         container_class.new(value: value)
-      end.to raise_error(Strict::InitializationError)
+      end.to raise_error(Strict::InitializationError) { |error|
+        expect(error.violations).to eq(
+          [Strict::Violation.new(path: [:value], code: :invalid, value: value, validator: value_class)]
+        )
+      }
       expect(value_class).not_to validate(value)
     end
   end
@@ -181,8 +185,27 @@ RSpec.describe Strict::RSpec do
         expect(String).to validate(1)
       end.to raise_error(
         RSpec::Expectations::ExpectationNotMetError,
-        "expected String to validate 1"
+        "expected String to validate 1\n\nviolations:\n  - at root: expected String, got 1"
       )
+    end
+
+    it "describes detailed violation paths" do
+      validator = Class.new do
+        include Strict::DetailedValidator
+
+        def violations(value)
+          return [] if Integer === value.a
+
+          [Strict::Violation.new(path: [:a], code: :invalid, value: value.a, validator: Integer)]
+        end
+      end.new
+      value = Struct.new(:a).new("1")
+
+      expect do
+        expect(validator).to validate(value)
+      end.to raise_error(RSpec::Expectations::ExpectationNotMetError) { |error|
+        expect(error.message).to include('at [:a]: expected Integer, got "1"')
+      }
     end
 
     it "describes an unexpectedly accepted value" do

--- a/spec/strict/rspec_spec.rb
+++ b/spec/strict/rspec_spec.rb
@@ -4,6 +4,32 @@ require "spec_helper"
 require "strict/rspec"
 
 RSpec.describe Strict::RSpec do
+  describe "composable Strict values" do
+    it "supports nested RSpec matchers in received arguments" do
+      nested_value_class = Struct.new(:a)
+      nested_validator = nested_value_class
+      value_class = Class.new do
+        include Strict::Value
+
+        attributes do
+          other_value nested_validator
+        end
+      end
+      receiver_class = Class.new do
+        def bar(value:); end
+      end
+      receiver = instance_spy(receiver_class)
+      receiver.bar(value: value_class.new(other_value: nested_value_class.new(1)))
+
+      expect(receiver).to have_received(:bar).with(
+        value: value_class.new(other_value: have_attributes(a: 1))
+      )
+      expect(receiver).not_to have_received(:bar).with(
+        value: value_class.new(other_value: have_attributes(a: 2))
+      )
+    end
+  end
+
   describe "strict_double" do
     it "builds a conforming interface implementation double" do
       interface_class = Class.new do

--- a/spec/strict/rspec_spec.rb
+++ b/spec/strict/rspec_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "strict/rspec"
+
+RSpec.describe Strict::RSpec do
+  describe "conform_to matcher" do
+    let(:interface_class) do
+      Class.new do
+        include Strict::Interface
+
+        expose(:call) do
+          value String
+          returns String
+        end
+      end
+    end
+
+    it "matches implementations that conform to the interface" do
+      implementation = Class.new do
+        def call(value:) = value
+      end.new
+
+      expect(implementation).to conform_to(interface_class)
+      expect(Object.new).not_to conform_to(interface_class)
+    end
+
+    it "includes Strict's conformance details when the implementation does not conform" do
+      expect do
+        expect(Object.new).to conform_to(interface_class)
+      end.to raise_error(RSpec::Expectations::ExpectationNotMetError) { |error|
+        expect(error.message).to include("to conform to #{interface_class.inspect}")
+        expect(error.message).to include("methods exposed in the interface were not defined")
+        expect(error.message).to include("call")
+      }
+    end
+  end
+
+  describe "validate matcher" do
+    it "matches when the validator accepts the value" do
+      expect(String).to validate("value")
+      expect(String).not_to validate(1)
+    end
+
+    it "describes a rejected value" do
+      expect do
+        expect(String).to validate(1)
+      end.to raise_error(
+        RSpec::Expectations::ExpectationNotMetError,
+        "expected String to validate 1"
+      )
+    end
+
+    it "describes an unexpectedly accepted value" do
+      expect do
+        expect(String).not_to validate("value")
+      end.to raise_error(
+        RSpec::Expectations::ExpectationNotMetError,
+        'expected String not to validate "value"'
+      )
+    end
+  end
+end

--- a/spec/strict/rspec_spec.rb
+++ b/spec/strict/rspec_spec.rb
@@ -4,6 +4,14 @@ require "spec_helper"
 require "strict/rspec"
 
 RSpec.describe Strict::RSpec do
+  describe "public surface" do
+    it "exposes the helper through RSpec without exposing adapter internals" do
+      expect(self).to respond_to(:strict_double)
+      expect(described_class.constants(false)).to be_empty
+      expect(described_class.singleton_methods(false)).to be_empty
+    end
+  end
+
   describe "composable Strict values" do
     it "supports nested RSpec matchers in received arguments" do
       nested_value_class = Struct.new(:a)

--- a/spec/strict/rspec_spec.rb
+++ b/spec/strict/rspec_spec.rb
@@ -1,10 +1,21 @@
 # frozen_string_literal: true
 
+require "open3"
 require "spec_helper"
 require "strict/rspec"
 
 RSpec.describe Strict::RSpec do
   describe "public surface" do
+    it "keeps the core require independent from RSpec" do
+      lib = File.expand_path("../../lib", __dir__)
+      script = 'require "strict"; abort "RSpec loaded" if defined?(RSpec)'
+
+      output, status = Open3.capture2e(RbConfig.ruby, "-I#{lib}", "-e", script)
+
+      expect(output).to be_empty
+      expect(status).to be_success
+    end
+
     it "exposes the helper through RSpec without exposing adapter internals" do
       expect(self).to respond_to(:strict_double)
       expect(described_class.constants(false)).to be_empty

--- a/spec/strict/rspec_spec.rb
+++ b/spec/strict/rspec_spec.rb
@@ -4,6 +4,114 @@ require "spec_helper"
 require "strict/rspec"
 
 RSpec.describe Strict::RSpec do
+  describe "strict_double" do
+    it "builds a conforming interface implementation double" do
+      interface_class = Class.new do
+        include Strict::Interface
+
+        expose(:call) do
+          value String
+          returns String
+        end
+
+        expose(:reset) { returns nil }
+      end
+
+      implementation = strict_double(interface_class, call: "result")
+
+      expect(implementation).to conform_to(interface_class)
+      expect(interface_class.new(implementation).call(value: "input")).to eq("result")
+      expect(implementation.reset).to be_nil
+    end
+
+    it "rejects stubs for methods outside the interface" do
+      interface_class = Class.new do
+        include Strict::Interface
+
+        expose(:call) { returns String }
+      end
+
+      expect do
+        strict_double(interface_class, unknown: true)
+      end.to raise_error(RSpec::Mocks::MockExpectationError)
+    end
+
+    it "builds a verifying double for a Strict value" do
+      value_class = Class.new do
+        include Strict::Value
+
+        attributes do
+          name String
+        end
+      end
+
+      value = strict_double(value_class, name: "test value")
+
+      expect(value.name).to eq("test value")
+      expect do
+        strict_double(value_class, unknown: true)
+      end.to raise_error(RSpec::Mocks::MockExpectationError)
+    end
+  end
+
+  describe "Strict validation of verifying doubles" do
+    let(:value_class) do
+      Class.new do
+        include Strict::Value
+
+        attributes do
+          name String
+        end
+      end
+    end
+
+    let(:container_class) do
+      value_validator = value_class
+
+      Class.new do
+        include Strict::Value
+
+        attributes do
+          value value_validator
+        end
+      end
+    end
+
+    it "accepts an instance double as a class-validated attribute" do
+      value = instance_double(value_class, name: "test value")
+
+      container = container_class.new(value: value)
+
+      expect(container.value).to be(value)
+      expect(value_class).to validate(value)
+    end
+
+    it "accepts instance doubles as signed parameters and return values" do
+      value_validator = value_class
+      callable_class = Class.new do
+        include Strict::Method
+
+        sig do
+          value value_validator
+          returns value_validator
+        end
+        def call(value) = value
+      end
+      value = instance_double(value_class)
+
+      expect(callable_class.new.call(value)).to be(value)
+    end
+
+    it "continues to reject plain doubles" do
+      value = double("value") # rubocop:disable RSpec/VerifiedDoubles
+
+      expect do
+        container_class.new(value: value)
+      end.to raise_error(Strict::InitializationError)
+      expect(value_class).not_to validate(value)
+    end
+  end
+
   describe "conform_to matcher" do
     let(:interface_class) do
       Class.new do


### PR DESCRIPTION
## Summary

- add opt-in `strict/rspec` integration with `validate` and `conform_to` matchers
- add `strict_double` for Strict values and interface implementations
- allow RSpec instance doubles and matcher placeholders through Strict validation, including nested collection validators
- support recursive RSpec argument matching for `Strict::Value` without changing value equality or hashing
- document the supported API, setup, compatibility boundary, changelog entry, and RBS helper contract

## Verification

- `bundle exec rake` (281 examples, 0 failures; RuboCop clean; RBS validation passed)
- built and unpacked the gem, confirming `lib/strict/rspec.rb` and `sig/strict/rspec.rbs` are packaged
