### PR TITLE
Preserve exact instances in Value and Object coercers

### DIFF
--- a/API.md
+++ b/API.md
@@ -69,7 +69,7 @@ Only one default option can be present on one declaration.
 - a class method name as a symbol;
 - `true`, which calls the class method `coerce_<attribute>`.
 
-The generated class `coercer` returns `nil` and non-hash-like values unchanged. For hash-like input, it recognizes declared symbol or string keys and initializes the class with those values.
+The generated class `coercer` returns `nil`, non-hash-like values, and instances of that exact class unchanged. A subclass instance is not an exact-class match: a parent class coercer treats it as hash-like input and creates a new parent instance from the parent's declared attributes. For other hash-like input, the coercer recognizes declared symbol or string keys and initializes the class with those values.
 
 ### Discriminated unions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Share declaration invariants between attributes and parameters, with isolated backing storage for every distinct attribute name.
 - Keep Strict configuration overrides in isolated internal thread-local storage to avoid collisions with application keys.
 - Generate attribute readers and writers through one shared implementation, with mutable writers bound directly to their declarations.
+- Return exact `Strict::Value` and `Strict::Object` instances unchanged from their class coercers while continuing to convert subclass instances.
 
 ### Performance
 

--- a/lib/strict/attributes/coercer.rb
+++ b/lib/strict/attributes/coercer.rb
@@ -12,7 +12,8 @@ module Strict
       end
 
       def call(value)
-        return value if value.nil? || !value.respond_to?(:to_h)
+        return value if value.nil? || value.instance_of?(attributes_class)
+        return value unless value.respond_to?(:to_h)
 
         coerce(value.to_h)
       end

--- a/spec/strict/object_spec.rb
+++ b/spec/strict/object_spec.rb
@@ -153,6 +153,12 @@ RSpec.describe Strict::Object do
     end.to raise_error(Strict::InitializationError)
   end
 
+  it "returns an exact instance unchanged from its coercer" do
+    instance = build(:strict_object)
+
+    expect(ObjectClass.coercer.call(instance)).to be(instance)
+  end
+
   it "converts subclass instances into new instances of the coercer's exact class" do
     person_class = Class.new do
       include Strict::Object

--- a/spec/strict/object_spec.rb
+++ b/spec/strict/object_spec.rb
@@ -153,6 +153,28 @@ RSpec.describe Strict::Object do
     end.to raise_error(Strict::InitializationError)
   end
 
+  it "converts subclass instances into new instances of the coercer's exact class" do
+    person_class = Class.new do
+      include Strict::Object
+
+      attributes do
+        name String
+      end
+    end
+    employee_class = Class.new(person_class) do
+      attributes do
+        employee_id String
+      end
+    end
+    employee = employee_class.new(name: "Ada", employee_id: "employee_123")
+
+    coerced = person_class.coercer.call(employee)
+
+    expect(coerced).to be_an_instance_of(person_class)
+    expect(coerced).not_to be(employee)
+    expect(coerced.to_h).to eq(name: "Ada")
+  end
+
   it "supports predicate and bang attribute names" do
     object_class = Class.new do
       include Strict::Object

--- a/spec/strict/value_spec.rb
+++ b/spec/strict/value_spec.rb
@@ -188,6 +188,12 @@ RSpec.describe Strict::Value do
     end.to raise_error(Strict::InitializationError)
   end
 
+  it "returns an exact instance unchanged from its coercer" do
+    instance = build(:value)
+
+    expect(ValueClass.coercer.call(instance)).to be(instance)
+  end
+
   it "converts subclass instances into new instances of the coercer's exact class" do
     person_class = Class.new do
       include Strict::Value

--- a/spec/strict/value_spec.rb
+++ b/spec/strict/value_spec.rb
@@ -187,4 +187,26 @@ RSpec.describe Strict::Value do
       ValueClass.coercer.call({})
     end.to raise_error(Strict::InitializationError)
   end
+
+  it "converts subclass instances into new instances of the coercer's exact class" do
+    person_class = Class.new do
+      include Strict::Value
+
+      attributes do
+        name String
+      end
+    end
+    employee_class = Class.new(person_class) do
+      attributes do
+        employee_id String
+      end
+    end
+    employee = employee_class.new(name: "Ada", employee_id: "employee_123")
+
+    coerced = person_class.coercer.call(employee)
+
+    expect(coerced).to be_an_instance_of(person_class)
+    expect(coerced).not_to be(employee)
+    expect(coerced.to_h).to eq(name: "Ada")
+  end
 end


### PR DESCRIPTION
## Summary

- return exact `Strict::Value` and `Strict::Object` instances unchanged from their class coercers
- preserve and characterize parent-coercer conversion of subclass instances
- document the exact-instance contract in the supported API and changelog

## Verification

- `bundle exec rake` (285 examples, 0 failures; 89 files with no RuboCop offenses; RBS signatures valid)
