### PR TITLE
Document configuration overrides as execution-context local

### DIFF
--- a/API.md
+++ b/API.md
@@ -269,7 +269,7 @@ Strict provides:
 
 The supported configuration options are `random` and `sample_rate`, with readers and writers. `random` must implement `Random::Formatter`. `sample_rate` must be in the inclusive range from `0` through `1`.
 
-Overrides are local to the current thread, can be nested, and are restored when a block returns or raises. An active override cannot be changed with `Strict.configure`.
+Overrides are local to the current execution context (fiber), can be nested, and are restored when a block returns or raises. Neither a newly created fiber nor a new thread inherits an active override. An active override cannot be changed with `Strict.configure`.
 
 Sampling controls validator calls. Coercion, signature-definition checks, and interface conformance checks still run when validation is sampled out.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 - Require interface implementations to cover every distinct exposed keyword parameter.
 - Reduce value and object hot-path allocations during initialization, `to_h`, equality, and hashing.
 - Share declaration invariants between attributes and parameters, with isolated backing storage for every distinct attribute name.
-- Keep Strict configuration overrides in isolated internal thread-local storage to avoid collisions with application keys.
+- Keep Strict configuration overrides in isolated internal execution-context storage to avoid collisions with application keys.
 - Generate attribute readers and writers through one shared implementation, with mutable writers bound directly to their declarations.
 
 ### Performance

--- a/README.md
+++ b/README.md
@@ -402,7 +402,7 @@ Strict.configure do |c|
   c.sample_rate = 1 # always run validation
 end
 
-# Locally within the block (only applies to the current thread)
+# Locally within the block (only applies to the current execution context)
 
 Strict.with_overrides(sample_rate: 0) do
   # Use Strict as you normally would
@@ -412,6 +412,9 @@ Strict.with_overrides(sample_rate: 0) do
   end
 end
 ```
+
+Overrides are local to the current execution context (fiber). They can be nested and are restored when a block returns
+or raises. Neither a newly created fiber nor a new thread inherits an active override.
 
 #### `Strict.configuration.random`
 

--- a/lib/strict.rb
+++ b/lib/strict.rb
@@ -10,7 +10,7 @@ module Strict
 
   class << self
     def configuration
-      thread_configuration || global_configuration
+      execution_context_override || global_configuration
     end
 
     def configure
@@ -20,27 +20,27 @@ module Strict
     end
 
     def with_overrides(**overrides)
-      original_thread_configuration = thread_configuration
+      original_override = execution_context_override
 
       begin
-        self.thread_configuration = Strict::Configuration.new(**configuration.to_h, **overrides)
+        self.execution_context_override = Strict::Configuration.new(**configuration.to_h, **overrides)
         yield
       ensure
-        self.thread_configuration = original_thread_configuration
+        self.execution_context_override = original_override
       end
     end
 
     private
 
     def overridden?
-      !!thread_configuration
+      !!execution_context_override
     end
 
-    def thread_configuration
+    def execution_context_override
       Thread.current[:__strict_configuration_override]
     end
 
-    def thread_configuration=(configuration)
+    def execution_context_override=(configuration)
       Thread.current[:__strict_configuration_override] = configuration
     end
 

--- a/spec/strict/strict_public_api_spec.rb
+++ b/spec/strict/strict_public_api_spec.rb
@@ -484,25 +484,50 @@ RSpec.describe Strict do
   end
 
   describe "configuration" do
-    it "supports nested thread-local overrides and restores them after errors" do
+    it "nests and restores overrides in the current execution context" do
       original_sample_rate = described_class.configuration.sample_rate
-      thread_sample_rate = Queue.new
 
-      expect do
-        described_class.with_overrides(sample_rate: 0) do
-          expect(described_class.configuration.sample_rate).to eq(0)
-          described_class.with_overrides(sample_rate: 0.5) do
-            expect(described_class.configuration.sample_rate).to eq(0.5)
-          end
-          expect(described_class.configuration.sample_rate).to eq(0)
-
-          Thread.new { thread_sample_rate << described_class.configuration.sample_rate }.join
-          raise "restore the override"
+      described_class.with_overrides(sample_rate: 0) do
+        expect(described_class.configuration.sample_rate).to eq(0)
+        described_class.with_overrides(sample_rate: 0.5) do
+          expect(described_class.configuration.sample_rate).to eq(0.5)
         end
-      end.to raise_error(RuntimeError, "restore the override")
+        expect(described_class.configuration.sample_rate).to eq(0)
+      end
 
-      expect(thread_sample_rate.pop).to eq(original_sample_rate)
       expect(described_class.configuration.sample_rate).to eq(original_sample_rate)
+    end
+
+    it "restores the previous override after an error" do
+      described_class.with_overrides(sample_rate: 0) do
+        expect do
+          described_class.with_overrides(sample_rate: 0.5) do
+            raise "restore the override"
+          end
+        end.to raise_error(RuntimeError, "restore the override")
+
+        expect(described_class.configuration.sample_rate).to eq(0)
+      end
+    end
+
+    it "does not inherit overrides in a new fiber" do
+      original_sample_rate = described_class.configuration.sample_rate
+
+      fiber_sample_rate = described_class.with_overrides(sample_rate: 0) do
+        Fiber.new { described_class.configuration.sample_rate }.resume
+      end
+
+      expect(fiber_sample_rate).to eq(original_sample_rate)
+    end
+
+    it "does not inherit overrides in a new thread" do
+      original_sample_rate = described_class.configuration.sample_rate
+
+      thread_sample_rate = described_class.with_overrides(sample_rate: 0) do
+        Thread.new { described_class.configuration.sample_rate }.value
+      end
+
+      expect(thread_sample_rate).to eq(original_sample_rate)
     end
 
     it "isolates overrides from application thread-local configuration" do

--- a/spec/strict/strict_public_api_spec.rb
+++ b/spec/strict/strict_public_api_spec.rb
@@ -530,7 +530,7 @@ RSpec.describe Strict do
       expect(thread_sample_rate).to eq(original_sample_rate)
     end
 
-    it "isolates overrides from application thread-local configuration" do
+    it "isolates overrides from application execution-context storage" do
       global_configuration = described_class.configuration
       application_configuration = Object.new
       original_application_configuration = Thread.current[:configuration]


### PR DESCRIPTION
## Summary

- describe `Strict.with_overrides` as local to the current execution context rather than the current thread
- keep private storage compatible with Ruby 3.3 while correcting its internal terminology
- characterize same-fiber nesting and restoration, exception restoration, and isolation from new fibers and threads

## Verification

- `bundle exec rake` (284 examples, 0 failures; 89 files inspected, no RuboCop offenses; RBS signatures valid)
