### PR TITLE
Make interface conformance substitutable

### DIFF
--- a/API.md
+++ b/API.md
@@ -162,9 +162,11 @@ The following behavior is outside the compatibility boundary:
 
 ### Interfaces
 
-`Strict::Interface` adds `expose` and `.coercer`. `expose(name) { ... }` defines a validated, keyword-forwarding instance method.
+`Strict::Interface` adds `expose`, `.coercer`, `.implemented_by?`, and `.verify_implementation!`. `expose(name) { ... }` defines a validated, keyword-forwarding instance method.
 
-Constructing an interface requires an implementation. The implementation must respond publicly to every exposed method. Its explicit parameters must be the required keywords declared by the interface. A keyword-rest parameter satisfies keyword coverage. Additional ordinary implementation methods, blocks, and a positional-rest parameter do not affect conformance.
+Constructing an interface requires an implementation. The implementation must respond publicly to every exposed method and accept every keyword declared by that method. It can accept an interface keyword as a required or optional keyword, or through a keyword-rest parameter. Additional required positional or keyword parameters do not conform because they can reject a valid interface call. Additional optional positional or keyword parameters, positional-rest parameters, blocks, and ordinary implementation methods do not affect conformance.
+
+`Interface.implemented_by?(adapter)` returns `true` or `false` without constructing an interface. `Interface.verify_implementation!(adapter)` performs the same check, returns `nil` when the adapter conforms, and otherwise raises `Strict::ImplementationDoesNotConformError` with the structured details described below. Interface construction uses this same check.
 
 Interface instances expose their `implementation`. The class coercer:
 
@@ -193,7 +195,7 @@ Loading the adapter registers the `validate` and `conform_to` matchers and adds 
 fails. RSpec matcher objects and compatible instance doubles are accepted as test values. Exact failure-message wording
 and formatting are not fixed.
 
-`expect(implementation).to conform_to(interface)` checks the same public method and required-keyword conformance as
+`expect(implementation).to conform_to(interface)` uses `interface.verify_implementation!` to check the same conformance as
 constructing the interface. It does not invoke exposed methods. A failed expectation includes the conformance error's
 details, without a fixed wording or formatting contract.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add inherited value and object attribute declarations and shared union attributes.
 - Add structured validation violations with paths, codes, rejected values, and validators for assignment, initialization, signed method calls, and returns, plus an optional detailed-validator protocol for custom nested failures.
 - Add opt-in RSpec matchers, verifying doubles, and nested matcher placeholders for Strict values and validations.
+- Add `implemented_by?` and `verify_implementation!` to check interface adapters without constructing an interface.
 
 ### Breaking changes
 
@@ -19,7 +20,7 @@
 - Compile signed-method invocation metadata once, reuse unchanged call arguments, and consolidate generated wrappers by owner.
 - Preserve validated explicit keywords when keyrest processing changes a signed call.
 - Forward validated interface calls directly to implementations and compile interface-conformance expectations once per interface definition.
-- Require interface implementations to cover every distinct exposed keyword parameter.
+- Check interface implementation signatures by substitutability: require every exposed keyword and reject only additional parameters that can constrain a valid interface call.
 - Reduce value and object hot-path allocations during initialization, `to_h`, equality, and hashing.
 - Share declaration invariants between attributes and parameters, with isolated backing storage for every distinct attribute name.
 - Keep Strict configuration overrides in isolated internal execution-context storage to avoid collisions with application keys.

--- a/README.md
+++ b/README.md
@@ -272,7 +272,15 @@ module Storages
   end
 end
 
-storage = Storage.new(Storages::Memory.new)
+adapter = Storages::Memory.new
+
+Storage.implemented_by?(adapter)
+# => true
+
+Storage.verify_implementation!(adapter)
+# => nil
+
+storage = Storage.new(adapter)
 # => #<Storage implementation=#<Storages::Memory>>
 
 storage.write(key: "some/path/to/file.rb", contents: "Hello")

--- a/lib/strict/interface.rb
+++ b/lib/strict/interface.rb
@@ -13,8 +13,15 @@ module Strict
         Interfaces::Coercer.new(self)
       end
 
-      def strict_interface_conformance
-        @strict_interface_conformance ||= Interfaces::Conformance.new(self)
+      def implemented_by?(implementation)
+        verify_implementation!(implementation)
+        true
+      rescue Strict::ImplementationDoesNotConformError
+        false
+      end
+
+      def verify_implementation!(implementation)
+        strict_interface_conformance.verify!(implementation)
       end
 
       def expose(method_name, &)
@@ -29,6 +36,12 @@ module Strict
         strict_instance_methods[method_name] = verifiable_method
         strict_interface_conformance.compile(verifiable_method)
         strict_method_wrapper(self).wrap(verifiable_method, invocation_target: :implementation)
+      end
+
+      private
+
+      def strict_interface_conformance
+        @strict_interface_conformance ||= Interfaces::Conformance.new(self)
       end
     end
   end

--- a/lib/strict/interfaces/conformance.rb
+++ b/lib/strict/interfaces/conformance.rb
@@ -66,26 +66,38 @@ module Strict
       def invalid_definition_for(expectation, implementation_parameters)
         matched_parameter_mask = 0
         has_keyword_splat = false
+        implementation_parameters.each do |kind, parameter_name|
+          case kind
+          when :keyrest
+            has_keyword_splat = true
+          when :keyreq, :key
+            parameter_index = expectation.parameter_names.index(parameter_name)
+            matched_parameter_mask |= 1 << parameter_index if parameter_index
+          end
+        end
+
         additional_parameters = nil
         non_keyword_parameters = nil
 
         implementation_parameters.each do |kind, parameter_name|
-          case kind
-          when :block, :rest
-            next
-          when :keyrest
-            has_keyword_splat = true
-            next
-          end
-
           parameter_index = expectation.parameter_names.index(parameter_name)
-          unless parameter_index
-            (additional_parameters ||= []) << parameter_name
-            next
-          end
+          case kind
+          when :keyreq
+            (additional_parameters ||= []) << parameter_name unless parameter_index
+          when :req
+            if parameter_index
+              matched_parameter_mask |= 1 << parameter_index
+              (non_keyword_parameters ||= []) << parameter_name
+            else
+              (additional_parameters ||= []) << parameter_name
+            end
+          when :opt
+            next unless parameter_index && !has_keyword_splat
+            next if matched_parameter_mask.anybits?(1 << parameter_index)
 
-          matched_parameter_mask |= 1 << parameter_index
-          (non_keyword_parameters ||= []) << parameter_name unless kind == :keyreq
+            matched_parameter_mask |= 1 << parameter_index
+            (non_keyword_parameters ||= []) << parameter_name
+          end
         end
 
         missing_parameters = missing_parameters_from(expectation, matched_parameter_mask) unless has_keyword_splat

--- a/lib/strict/interfaces/instance.rb
+++ b/lib/strict/interfaces/instance.rb
@@ -6,7 +6,7 @@ module Strict
       attr_reader :implementation
 
       def initialize(implementation)
-        self.class.strict_interface_conformance.verify!(implementation)
+        self.class.verify_implementation!(implementation)
 
         @implementation = implementation
       end

--- a/lib/strict/rspec.rb
+++ b/lib/strict/rspec.rb
@@ -32,7 +32,7 @@ module Strict
         end
 
         def stubs_for(strict_class, stubs)
-          return stubs unless strict_class.respond_to?(:strict_interface_conformance)
+          return stubs unless strict_class.respond_to?(:verify_implementation!)
 
           strict_class.strict_instance_methods.to_h { |name, _method| [name, nil] }.merge(stubs)
         end
@@ -121,7 +121,7 @@ module Strict
     ::RSpec::Matchers.define :conform_to do |interface|
       match do |implementation|
         @conformance_error = nil
-        interface.new(implementation)
+        interface.verify_implementation!(implementation)
         true
       rescue Strict::ImplementationDoesNotConformError => e
         @conformance_error = e

--- a/sig/strict.rbs
+++ b/sig/strict.rbs
@@ -94,6 +94,8 @@ module Strict
 
     def expose: (String | Symbol name) { () [self: _MethodDsl] -> untyped } -> void
     def coercer: () -> _Coercer[untyped, untyped]
+    def implemented_by?: (untyped adapter) -> bool
+    def verify_implementation!: (untyped adapter) -> nil
   end
 
   interface _UnionVariantClass

--- a/spec/strict/interface_spec.rb
+++ b/spec/strict/interface_spec.rb
@@ -130,6 +130,17 @@ RSpec.describe Strict::Interface do
       expect(interface.no_params).to eq("4")
     end
 
+    it "uses the public implementation verification API" do
+      implementation = Class.new do
+        def call(one:, two:) = "#{one}#{two}"
+      end.new
+
+      allow(interface_class).to receive(:verify_implementation!).and_call_original
+
+      expect(interface_class.new(implementation).implementation).to be(implementation)
+      expect(interface_class).to have_received(:verify_implementation!).with(implementation)
+    end
+
     it "raises when missing a parameter" do
       expect do
         interface_class.new(
@@ -170,7 +181,7 @@ RSpec.describe Strict::Interface do
     end
     # rubocop:enable Naming/MethodParameterName
 
-    it "raises when given an extra parameter" do
+    it "raises when given an extra required keyword parameter" do
       expect do
         interface_class.new(
           Class.new do
@@ -178,6 +189,22 @@ RSpec.describe Strict::Interface do
           end.new
         )
       end.to raise_error(Strict::ImplementationDoesNotConformError)
+    end
+
+    it "accepts an extra optional keyword parameter" do
+      implementation = Class.new do
+        def call(one:, two:, three: nil) = "#{one}#{two}#{three}"
+      end.new
+
+      expect(interface_class.new(implementation).call(one: "1", two: "2")).to eq("12")
+    end
+
+    it "accepts an extra optional positional parameter" do
+      implementation = Class.new do
+        def call(prefix = nil, one:, two:) = "#{prefix}#{one}#{two}"
+      end.new
+
+      expect(interface_class.new(implementation).call(one: "1", two: "2")).to eq("12")
     end
 
     it "raises when given a non-keyword parameter" do
@@ -190,22 +217,12 @@ RSpec.describe Strict::Interface do
       end.to raise_error(Strict::ImplementationDoesNotConformError)
     end
 
-    it "raises when an explicit keyword parameter is optional" do
+    it "accepts an expected keyword that is optional" do
       implementation = Class.new do
-        def call(one:, two: nil); end
+        def call(one:, two: nil) = "#{one}#{two}"
       end.new
 
-      expect do
-        interface_class.new(implementation)
-      end.to raise_error(Strict::ImplementationDoesNotConformError) { |error|
-        expect(error.invalid_method_definitions).to eq(
-          call: {
-            additional_parameters: [],
-            missing_parameters: [],
-            non_keyword_parameters: [:two]
-          }
-        )
-      }
+      expect(interface_class.new(implementation).call(one: "1", two: "2")).to eq("12")
     end
 
     it "raises when missing a method" do
@@ -290,7 +307,7 @@ RSpec.describe Strict::Interface do
       end.not_to raise_error
     end
 
-    it "raises when non-keyword args are partially splatted" do
+    it "raises when a required positional parameter precedes splatted positional arguments" do
       expect do
         interface_class.new(
           Class.new do
@@ -329,6 +346,40 @@ RSpec.describe Strict::Interface do
             non_keyword_parameters: []
           }
         )
+      }
+    end
+  end
+
+  describe ".implemented_by?" do
+    it "returns whether an adapter conforms" do
+      implementation = Class.new do
+        def call(one:, two: nil); end
+      end.new
+
+      expect(interface_class.implemented_by?(implementation)).to be(true)
+      expect(interface_class.implemented_by?(Object.new)).to be(false)
+    end
+  end
+
+  describe ".verify_implementation!" do
+    it "returns nil when the adapter conforms" do
+      implementation = Class.new do
+        def call(one:, two:); end
+      end.new
+
+      expect(interface_class.verify_implementation!(implementation)).to be_nil
+    end
+
+    it "raises with structured details when the adapter does not conform" do
+      implementation = Object.new
+
+      expect do
+        interface_class.verify_implementation!(implementation)
+      end.to raise_error(Strict::ImplementationDoesNotConformError) { |error|
+        expect(error.interface).to be(interface_class)
+        expect(error.receiver).to be(implementation)
+        expect(error.missing_methods).to eq([:call])
+        expect(error.invalid_method_definitions).to be_empty
       }
     end
   end
@@ -381,5 +432,9 @@ RSpec.describe Strict::Interface do
     end.new
 
     expect(interface_class.new(implementation).call(if: "yes")).to eq("yes")
+  end
+
+  it "keeps internal conformance reflection private" do
+    expect(interface_class).not_to respond_to(:strict_interface_conformance)
   end
 end

--- a/spec/strict/rspec_spec.rb
+++ b/spec/strict/rspec_spec.rb
@@ -194,6 +194,19 @@ RSpec.describe Strict::RSpec do
       expect(Object.new).not_to conform_to(interface_class)
     end
 
+    it "uses the interface implementation verification API without constructing the interface" do
+      implementation = Class.new do
+        def call(value: nil) = value
+      end.new
+
+      allow(interface_class).to receive(:verify_implementation!).and_call_original
+      allow(interface_class).to receive(:new).and_call_original
+
+      expect(implementation).to conform_to(interface_class)
+      expect(interface_class).to have_received(:verify_implementation!).with(implementation)
+      expect(interface_class).not_to have_received(:new)
+    end
+
     it "includes Strict's conformance details when the implementation does not conform" do
       expect do
         expect(Object.new).to conform_to(interface_class)


### PR DESCRIPTION
## Summary

- check interface implementations by substitutability for keyword-forwarding calls
- add `implemented_by?` and `verify_implementation!` as public interface class APIs
- route interface construction and the RSpec `conform_to` matcher through `verify_implementation!`
- document the contract and add RBS signatures

## Substitutability rule

An implementation must accept every keyword declared by the interface, either as a required keyword, an optional keyword, or through `**kwargs`. Extra required positional or keyword parameters remain invalid because they can make a valid interface call fail. Extra optional positional or keyword parameters, `*args`, and blocks are accepted because they do not constrain interface callers.

`verify_implementation!` returns `nil` on success and raises the existing `Strict::ImplementationDoesNotConformError` with structured details on failure. `implemented_by?` converts that result to a boolean.

## Compatibility impact

This pre-2.0 change broadens conformance for implementations that were previously rejected only because they used optional expected keywords or declared additional optional parameters. Implementations with missing interface keywords or additional required parameters remain nonconforming. The existing conformance exception and its structured detail fields remain in place where a failure still applies. The internal compiled-conformance reflection helper is now private.

## Verification

- `bundle exec rake`
  - 289 examples, 0 failures
  - 89 files inspected, no RuboCop offenses
  - RBS validation passed
