### PR TITLE
Use validator coercers by default

### DIFF
--- a/API.md
+++ b/API.md
@@ -67,7 +67,10 @@ Only one default option can be present on one declaration.
 
 - a callable;
 - a class method name as a symbol;
-- `true`, which calls the class method `coerce_<attribute>`.
+- `true`, which calls the class method `coerce_<attribute>`;
+- `false`, which disables coercion inherited from the validator.
+
+When `coerce:` is omitted and the validator responds to `coercer`, Strict uses `validator.coercer`.
 
 The generated class `coercer` returns `nil`, non-hash-like values, and instances of that exact class unchanged. A subclass instance is not an exact-class match: a parent class coercer treats it as hash-like input and creates a new parent instance from the parent's declared attributes. For other hash-like input, the coercer recognizes declared symbol or string keys and initializes the class with those values.
 
@@ -132,11 +135,11 @@ The union class `coercer`:
 - dispatches hash-like input through the selected variant's value coercer;
 - raises `ArgumentError` when the discriminator is missing or unknown.
 
-A union class can be an attribute or method validator. Add its coercer when the declaration must also accept hash-like input:
+A union class can be an attribute or method validator. Declarations use its coercer automatically, so they accept hash-like input unless coercion is disabled:
 
 ```ruby
 payment_result PaymentResult
-coerced_payment_result PaymentResult, coerce: PaymentResult.coercer
+strict_payment_result PaymentResult, coerce: false
 ```
 
 Declaring a discriminator more than once, declaring equivalent duplicate string or symbol tags, using an invalid variant name or tag, replacing an existing generated constant, declaring multiple union or variant attribute blocks, declaring union attributes after a variant, or redeclaring the discriminator raises `ArgumentError`. Declaration return values, generated-class reflection details, and the exact text of declaration and coercion errors are outside the compatibility boundary.
@@ -173,6 +176,8 @@ Interface instances expose their `implementation`. The class coercer:
 - returns `nil` unchanged;
 - returns an instance of that exact interface unchanged;
 - otherwise wraps the value and checks conformance.
+
+When an interface class is an attribute or parameter validator, declarations use this coercer automatically.
 
 Interface subclassing and re-exposing a method are outside the compatibility boundary.
 
@@ -221,6 +226,8 @@ classes, RSpec proxy metadata, and reflection details are outside the compatibil
 ## Validators and coercers
 
 Any object that implements `===` can be a validator. This includes classes, modules, literals, and custom validators. When a validator rejects a value, Strict reports that validator in one `:invalid` violation at the current path.
+
+Attribute and parameter declarations automatically use `validator.coercer` when the validator responds to `coercer`. An explicit `coerce:` value takes precedence, and `coerce: false` disables this automatic coercion.
 
 A custom validator can opt into nested structured failures by including `Strict::DetailedValidator` and implementing `violations(value)`. The method must return an array of `Strict::Violation` records and return an empty array when the value is valid. Each violation path is relative to the validated value; Strict prefixes paths when the validator is nested inside a declaration or a built-in detailed validator. `Strict::DetailedValidator` implements `===` from `violations`, so the custom validator does not need to implement both methods.
 

--- a/API.md
+++ b/API.md
@@ -266,6 +266,10 @@ They also provide these coercer constructors:
 - `ToArray(with: nil)`
 - `ToHash(with_keys: nil, with_values: nil)`
 
+`ArrayOf` provides a coercer with the same array-like conversion as `ToArray` and uses its element validator's coercer when available. `HashOf` provides the corresponding `ToHash` behavior and uses its key and value validators' coercers when available. This coercion composes recursively, such as for `ArrayOf(ValueClass)` or `HashOf(String => ArrayOf(ValueClass))`.
+
+The other built-in validators do not provide coercers. Their conversions have no single safe default: logical validators cannot unambiguously select or order coercers, ranges have no supported conversion contract, and booleans have no canonical input conversion.
+
 The constructors' validation and conversion results are public. Their concrete `Strict::Validators::*` and `Strict::Coercers::*` classes, metadata readers, and exact string representations are not public API.
 
 ## Configuration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Check interface implementation signatures by substitutability: require every exposed keyword and reject only additional parameters that can constrain a valid interface call.
 - Reduce value and object hot-path allocations during initialization, `to_h`, equality, and hashing.
 - Share declaration invariants between attributes and parameters, with isolated backing storage for every distinct attribute name.
+- Automatically use a validator's coercer for attributes and parameters unless the declaration overrides or disables coercion.
 - Keep Strict configuration overrides in isolated internal execution-context storage to avoid collisions with application keys.
 - Generate attribute readers and writers through one shared implementation, with mutable writers bound directly to their declarations.
 - Return exact `Strict::Value` and `Strict::Object` instances unchanged from their class coercers while continuing to convert subclass instances.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Reduce value and object hot-path allocations during initialization, `to_h`, equality, and hashing.
 - Share declaration invariants between attributes and parameters, with isolated backing storage for every distinct attribute name.
 - Automatically use a validator's coercer for attributes and parameters unless the declaration overrides or disables coercion.
+- Propagate default coercion through `ArrayOf` elements and `HashOf` keys and values.
 - Keep Strict configuration overrides in isolated internal execution-context storage to avoid collisions with application keys.
 - Generate attribute readers and writers through one shared implementation, with mutable writers bound directly to their declarations.
 - Return exact `Strict::Value` and `Strict::Object` instances unchanged from their class coercers while continuing to convert subclass instances.

--- a/README.md
+++ b/README.md
@@ -203,6 +203,8 @@ end
 
 The module provides `===` from `violations`, and Strict prefixes each relative path with its enclosing attribute, parameter, or collection path.
 
+When an attribute or parameter validator provides a `.coercer`, Strict uses it automatically before validation. An explicit `coerce:` value overrides it, and `coerce: false` disables it. This lets nested Strict values, unions, and interfaces accept the input handled by their class coercers without repeating `coerce:` in each declaration.
+
 ### `Strict::Method`
 
 ```rb

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ end
 
 The module provides `===` from `violations`, and Strict prefixes each relative path with its enclosing attribute, parameter, or collection path.
 
-When an attribute or parameter validator provides a `.coercer`, Strict uses it automatically before validation. An explicit `coerce:` value overrides it, and `coerce: false` disables it. This lets nested Strict values, unions, and interfaces accept the input handled by their class coercers without repeating `coerce:` in each declaration.
+When an attribute or parameter validator provides a `.coercer`, Strict uses it automatically before validation. An explicit `coerce:` value overrides it, and `coerce: false` disables it. This lets nested Strict values, unions, and interfaces accept the input handled by their class coercers without repeating `coerce:` in each declaration. `ArrayOf` and `HashOf` propagate coercers from their element, key, and value validators, so compositions such as `ArrayOf(ValueClass)` also coerce automatically.
 
 ### `Strict::Method`
 

--- a/lib/strict/declaration.rb
+++ b/lib/strict/declaration.rb
@@ -5,7 +5,12 @@ module Strict
     NOT_PROVIDED = ::Object.new.freeze
 
     class << self
-      def make(name, validator = Validators::Anything.instance, coerce: false, **defaults)
+      def make(
+        name,
+        validator = Validators::Anything.instance,
+        coerce: validator.respond_to?(:coercer) ? validator.coercer : false,
+        **defaults
+      )
         unless valid_defaults?(**defaults)
           raise ArgumentError, "Only one of 'default', 'default_value', or 'default_generator' can be provided"
         end

--- a/lib/strict/validators/array_of.rb
+++ b/lib/strict/validators/array_of.rb
@@ -11,6 +11,11 @@ module Strict
         @element_validator = element_validator
       end
 
+      def coercer
+        element_coercer = element_validator.coercer if element_validator.respond_to?(:coercer)
+        Coercers::Array.new(element_coercer)
+      end
+
       def violations(value)
         return Validation.invalid(self, value) unless Array === value
 

--- a/lib/strict/validators/hash_of.rb
+++ b/lib/strict/validators/hash_of.rb
@@ -12,6 +12,12 @@ module Strict
         @value_validator = value_validator
       end
 
+      def coercer
+        key_coercer = key_validator.coercer if key_validator.respond_to?(:coercer)
+        value_coercer = value_validator.coercer if value_validator.respond_to?(:coercer)
+        Coercers::Hash.new(key_coercer, value_coercer)
+      end
+
       # rubocop:disable Metrics/MethodLength
       def violations(value)
         return Validation.invalid(self, value) unless Hash === value

--- a/sig/strict.rbs
+++ b/sig/strict.rbs
@@ -9,6 +9,12 @@ module Strict
     def call: (A value) -> B
   end
 
+  interface _CoercingValidator
+    include _Validator
+
+    def coercer: () -> _Coercer[untyped, untyped]
+  end
+
   interface _AttributeDescriptor
     def name: () -> Symbol
     def validator: () -> _Validator
@@ -25,9 +31,9 @@ module Strict
     def AllOf: (*_Validator validators) -> _Validator
     def AnyOf: (*_Validator validators) -> _Validator
     def Anything: () -> _Validator
-    def ArrayOf: (_Validator element_validator) -> _Validator
+    def ArrayOf: (_Validator element_validator) -> _CoercingValidator
     def Boolean: () -> _Validator
-    def HashOf: (Hash[_Validator, _Validator] validators) -> _Validator
+    def HashOf: (Hash[_Validator, _Validator] validators) -> _CoercingValidator
     def RangeOf: (_Validator element_validator) -> _Validator
   end
 

--- a/spec/strict/attribute_spec.rb
+++ b/spec/strict/attribute_spec.rb
@@ -39,6 +39,25 @@ RSpec.describe Strict::Attribute do
       expect(attribute.coercer).to be_truthy
     end
 
+    it "uses the validator's coercer by default" do
+      coercer = ->(value) { value.to_s }
+      validator = Object.new
+      validator.define_singleton_method(:coercer) { coercer }
+
+      attribute = described_class.make(:attr_name, validator)
+
+      expect(attribute.coercer).to be(coercer)
+    end
+
+    it "allows the validator's coercer to be disabled" do
+      validator = Object.new
+      validator.define_singleton_method(:coercer) { ->(value) { value.to_s } }
+
+      attribute = described_class.make(:attr_name, validator, coerce: false)
+
+      expect(attribute.coercer).to be(false)
+    end
+
     it "accepts a value for 'default'" do
       attribute = described_class.make(:attr_name, default: 1)
 

--- a/spec/strict/interface_spec.rb
+++ b/spec/strict/interface_spec.rb
@@ -406,6 +406,22 @@ RSpec.describe Strict::Interface do
         InterfaceTest::Interface.coercer.call(InterfaceTest::BadImplementation.new)
       end.to raise_error(Strict::ImplementationDoesNotConformError)
     end
+
+    it "automatically wraps implementations when the interface is used as a validator" do
+      value_class = Class.new do
+        include Strict::Value
+
+        attributes do
+          implementation InterfaceTest::Interface
+        end
+      end
+      implementation = InterfaceTest::GoodImplementation.new
+
+      interface = value_class.new(implementation:).implementation
+
+      expect(interface).to be_an_instance_of(InterfaceTest::Interface)
+      expect(interface.implementation).to be(implementation)
+    end
   end
 
   describe "exposed methods" do

--- a/spec/strict/parameter_spec.rb
+++ b/spec/strict/parameter_spec.rb
@@ -42,6 +42,16 @@ RSpec.describe Strict::Parameter do
       expect(parameter.coercer).to be_truthy
     end
 
+    it "uses the validator's coercer by default" do
+      coercer = ->(value) { value.to_s }
+      validator = Object.new
+      validator.define_singleton_method(:coercer) { coercer }
+
+      parameter = described_class.make(:attr_name, validator)
+
+      expect(parameter.coercer).to be(coercer)
+    end
+
     it "accepts a value for 'default'" do
       parameter = described_class.make(:attr_name, default: 1)
 

--- a/spec/strict/strict_public_api_spec.rb
+++ b/spec/strict/strict_public_api_spec.rb
@@ -294,6 +294,33 @@ RSpec.describe Strict do
         )
       end.to raise_error(Strict::InitializationError)
     end
+
+    it "propagates coercion through array and hash validators" do
+      item_class = Class.new do
+        include Strict::Value
+
+        attributes do
+          name String
+        end
+      end
+      collection_class = Class.new do
+        include Strict::Value
+
+        attributes do
+          items ArrayOf(item_class)
+          items_by_group HashOf(String => ArrayOf(item_class))
+        end
+      end
+
+      collection = collection_class.new(
+        items: [{ name: "one" }],
+        items_by_group: [["all", [{ name: "one" }]]]
+      )
+
+      item = item_class.new(name: "one")
+      expect(collection.items).to eq([item])
+      expect(collection.items_by_group).to eq("all" => [item])
+    end
   end
 
   describe "signed methods" do

--- a/spec/strict/union_spec.rb
+++ b/spec/strict/union_spec.rb
@@ -122,25 +122,22 @@ RSpec.describe Strict::Union do
     expect(symbol_input).to eq(authorized)
   end
 
-  it "works as an attribute validator with optional coercion" do
+  it "automatically coerces values when used as an attribute validator" do
     result_class = union_class
     container_class = Class.new do
       include Strict::Value
 
       attributes do
         payment_result result_class
-        coerced_payment_result result_class, coerce: result_class.coercer
       end
     end
     payment_result = union_class::Declined.new(reason: "insufficient_funds")
 
     container = container_class.new(
-      payment_result: payment_result,
-      coerced_payment_result: { "status" => "declined", "reason" => "insufficient_funds" }
+      payment_result: { "status" => "declined", "reason" => "insufficient_funds" }
     )
 
-    expect(container.payment_result).to be(payment_result)
-    expect(container.coerced_payment_result).to eq(payment_result)
+    expect(container.payment_result).to eq(payment_result)
   end
 
   it "leaves existing members, nil, and non-hash-like values unchanged" do

--- a/spec/strict/validators/array_of_spec.rb
+++ b/spec/strict/validators/array_of_spec.rb
@@ -23,6 +23,16 @@ RSpec.describe Strict::Validators::ArrayOf do
     end
   end
 
+  describe "#coercer" do
+    it "coerces array-like values and their elements" do
+      element_validator = Object.new
+      element_validator.define_singleton_method(:coercer) { ->(value) { value.to_s } }
+      array_of = described_class.new(element_validator)
+
+      expect(array_of.coercer.call(1..3)).to eq(%w[1 2 3])
+    end
+  end
+
   describe "#to_s" do
     it "is meaningful" do
       array_of = described_class.new("2")

--- a/spec/strict/validators/hash_of_spec.rb
+++ b/spec/strict/validators/hash_of_spec.rb
@@ -28,6 +28,18 @@ RSpec.describe Strict::Validators::HashOf do
     end
   end
 
+  describe "#coercer" do
+    it "coerces hash-like values, keys, and entry values" do
+      key_validator = Object.new
+      key_validator.define_singleton_method(:coercer) { ->(key) { key.to_sym } }
+      value_validator = Object.new
+      value_validator.define_singleton_method(:coercer) { ->(value) { value.to_s } }
+      hash_of = described_class.new(key_validator, value_validator)
+
+      expect(hash_of.coercer.call([["one", 1]])).to eq(one: "1")
+    end
+  end
+
   describe "#to_s" do
     it "is meaningful" do
       hash_of = described_class.new("2", "3")


### PR DESCRIPTION
## Summary

- use a validator's coercer automatically for attributes and parameters, with explicit overrides and opt-out support
- propagate coercion through `ArrayOf` elements and `HashOf` keys and values
- document the coercion contract and expose coercing validators in RBS

## Verification

- `bundle exec rake`
