### PR TITLE
Harden pre-2.0 declaration contracts

### DIFF
--- a/API.md
+++ b/API.md
@@ -73,8 +73,6 @@ Only one default option can be present on one declaration.
 - a class method name as a symbol;
 - `true`, which calls the class method `coerce_<attribute>`.
 
-When `coerce:` is omitted and the validator responds to `coercer`, Strict uses `validator.coercer`.
-
 Other coercer forms raise `ArgumentError` at declaration time. Strict does not require a class-method coercer selected by a symbol or `true` to exist when the attribute is declared. The receiving class resolves it during initialization or assignment, so a subclass can provide or override it.
 
 The generated class `coercer` returns `nil`, non-hash-like values, and instances of that exact class unchanged. A subclass instance is not an exact-class match: a parent class coercer treats it as hash-like input and creates a new parent instance from the parent's declared attributes. For other hash-like input, the coercer recognizes declared symbol or string keys and initializes the class with those values.

--- a/API.md
+++ b/API.md
@@ -20,7 +20,7 @@ The former `extend Strict::Method` and `extend Strict::Interface` forms are not 
 
 `Strict::Value` and `Strict::Object` add an `attributes` declaration block. Each declaration accepts an attribute name, an optional validator, `coerce:`, and one of `default:`, `default_value:`, or `default_generator:`.
 
-Attribute names can be ordinary identifiers, Ruby reserved words declared through `strict_attribute`, or names ending in `?` or `!`. Each distinct name has independent backing storage, including names that differ only by a trailing `?` or `!`. A mutable object's punctuation writer can be called with `public_send`, for example `object.public_send(:"active?=", false)`.
+Attribute names must be strings or symbols in the supported identifier shape: a lowercase ASCII letter or underscore, followed by ASCII letters, digits, or underscores, with one optional trailing `?` or `!`. Ruby reserved words use `strict_attribute`, for example `strict_attribute :if`. Empty names, operators, setters, and other method-name forms are rejected. Each distinct supported name has independent backing storage, including names that differ only by a trailing `?` or `!`. A mutable object's punctuation writer can be called with `public_send`, for example `object.public_send(:"active?=", false)`.
 
 Both capabilities provide:
 
@@ -40,7 +40,9 @@ Both capabilities provide:
 - `==` and `eql?`, based on exact class and attribute values;
 - `hash`, consistent with `eql?`.
 
-A subclass inherits its parent's attributes. A subclass `attributes` block adds its declarations after the inherited declarations without changing the parent. Attribute redeclaration, multiple `attributes` blocks on the same class, and generated-method collisions are outside the compatibility boundary.
+A class can execute at most one `attributes` block, and an empty block counts as that one block. A subclass inherits its parent's attributes and can execute one additive `attributes` block without changing the parent. An attribute cannot duplicate another attribute in the same block or an inherited attribute.
+
+Before it installs generated methods, Strict rejects an attribute whose reader would collide with any existing public, protected, or private instance method. This includes methods supplied by Ruby and Strict, such as `class`, `to_h`, `inspect`, `hash`, `eql?`, `initialize`, `pretty_print`, and `public_send`. `Strict::Object` applies the same check to its generated writer. Strict does not police methods defined after the `attributes` block; later overrides remain unsupported. Duplicate attributes, repeated blocks, generated-method collisions, and invalid names or declaration options raise `ArgumentError` at declaration time.
 
 #### Attribute introspection
 
@@ -57,7 +59,7 @@ The descriptor's concrete class and other methods are implementation details.
 - `default: value` uses the value directly.
 - `default: callable` calls it for each default.
 - `default_value: value` preserves the value even when it is callable.
-- `default_generator: callable` calls it for each default.
+- `default_generator: callable` calls it for each default and requires an object that responds to `call`.
 
 Only one default option can be present on one declaration.
 
@@ -65,12 +67,15 @@ Only one default option can be present on one declaration.
 
 `coerce:` accepts:
 
+- omission, which uses `validator.coercer` when available and otherwise disables coercion;
+- `false`, which disables coercion inherited from the validator;
 - a callable;
 - a class method name as a symbol;
-- `true`, which calls the class method `coerce_<attribute>`;
-- `false`, which disables coercion inherited from the validator.
+- `true`, which calls the class method `coerce_<attribute>`.
 
 When `coerce:` is omitted and the validator responds to `coercer`, Strict uses `validator.coercer`.
+
+Other coercer forms raise `ArgumentError` at declaration time. Strict does not require a class-method coercer selected by a symbol or `true` to exist when the attribute is declared. The receiving class resolves it during initialization or assignment, so a subclass can provide or override it.
 
 The generated class `coercer` returns `nil`, non-hash-like values, and instances of that exact class unchanged. A subclass instance is not an exact-class match: a parent class coercer treats it as hash-like input and creates a new parent instance from the parent's declared attributes. For other hash-like input, the coercer recognizes declared symbol or string keys and initializes the class with those values.
 
@@ -122,7 +127,7 @@ PaymentResult::Authorized.new(
 # => { status: "payment.authorized", request_id: "request_123", authorization_id: "auth_123", amount_in_cents: 1_000 }
 ```
 
-Variants therefore use the documented `Strict::Value` behavior for initialization, validation, coercion, defaults, copying, equality, hashing, conversion, inspection, and pattern matching. A variant declaration cannot redeclare the discriminator. The union base cannot be instantiated directly.
+Variants therefore use the documented `Strict::Value` behavior for initialization, validation, coercion, defaults, copying, equality, hashing, conversion, inspection, pattern matching, and declaration errors. A variant attribute cannot duplicate the discriminator or a shared union attribute, and generated readers cannot collide with methods defined in the variant block. The union base cannot be instantiated directly.
 
 `PaymentResult === value` is true only when `value` has the exact class of a registered variant. Generated variant classes retain normal Ruby class matching, including matching instances of their subclasses. Union and variant inheritance are outside the compatibility boundary.
 
@@ -148,17 +153,17 @@ Declaring a discriminator more than once, declaring equivalent duplicate string 
 
 `Strict::Method` adds `sig`, which applies to the next instance or singleton method definition. A signature supports required and optional positional parameters, `*rest`, required and optional keyword parameters, `**keyrest`, and an optional `returns` declaration. Blocks pass through without validation.
 
-Parameter declarations accept a validator, a callable `coerce:`, and the three default forms described above. `strict_parameter` supports names that cannot be expressed as ordinary calls in the DSL.
+Parameter declaration names must be supported strings or symbols in the identifier shape documented for attributes and must match the signed Ruby method's parameters. `strict_parameter` supports Ruby reserved words that cannot be expressed as ordinary calls in the DSL. Parameter declarations accept a validator, `coerce: false` or a callable coercer, and the three default forms described above. Other coercer forms raise `ArgumentError` at declaration time.
 
-Strict verifies that signature names match the method definition. Calls coerce parameters, validate parameters, invoke the method, and validate its return value. A signature with no `returns` declaration accepts any return value.
+Strict verifies that signature names match the method definition. Calls coerce parameters, validate parameters, invoke the method, and validate its return value. `returns` is validate-only: the exact object produced by the method is the object returned to its caller. It does not accept `coerce:` or any other keyword and never transforms the returned value. A signature with no `returns` declaration accepts any return value.
+
+A signature cannot declare the same parameter more than once or contain more than one `returns` declaration. Invalid names, invalid defaults or coercers, duplicate parameters, repeated returns, and unsupported return options raise `ArgumentError` when the signature is declared. Exact error messages are not fixed.
 
 Inherited signed methods remain validated. A subclass override is unsigned unless the subclass provides a new signature.
 
 The following behavior is outside the compatibility boundary:
 
-- return-value coercion;
 - private or protected signed methods;
-- duplicate parameter declarations;
 - repeated signatures or same-class method redefinition;
 - DSL expression return values;
 - generated wrapper owners, ancestors, parameters, source locations, or other reflection details.
@@ -284,7 +289,7 @@ The supported configuration options are `random` and `sample_rate`, with readers
 
 Overrides are local to the current execution context (fiber), can be nested, and are restored when a block returns or raises. Neither a newly created fiber nor a new thread inherits an active override. An active override cannot be changed with `Strict.configure`.
 
-Sampling controls validator calls. Coercion, signature-definition checks, and interface conformance checks still run when validation is sampled out.
+Sampling controls validator calls. Attribute and parameter coercion, signature-definition checks, and interface conformance checks still run when validation is sampled out. Return validation can be sampled out, but return coercion never occurs.
 
 Direct construction of `Strict::Configuration`, its `validate?` and `to_h` methods, block return values, and configuration object identity are outside the compatibility boundary.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 ### Breaking changes
 
 - Standardize all four capabilities on `include`: `Strict::Value`, `Strict::Object`, `Strict::Method`, and `Strict::Interface`. The legacy `extend Strict::Method` and `extend Strict::Interface` forms are outside the supported next-major API.
+- Make signed method returns validate-only. `returns` rejects coercion options, validates the original result, and preserves its identity for the caller.
+- Reject malformed, duplicate, repeated, or method-colliding attribute and signature declarations with `ArgumentError` instead of silently replacing declarations or installing pathological methods.
 
 ### Changed
 
@@ -28,6 +30,7 @@
 - Keep Strict configuration overrides in isolated internal execution-context storage to avoid collisions with application keys.
 - Generate attribute readers and writers through one shared implementation, with mutable writers bound directly to their declarations.
 - Return exact `Strict::Value` and `Strict::Object` instances unchanged from their class coercers while continuing to convert subclass instances.
+- Validate declaration names, explicit default generators, and capability-specific coercer forms before installing attributes or signatures.
 
 ### Performance
 

--- a/README.md
+++ b/README.md
@@ -235,6 +235,8 @@ UpdateEmail.new.call(user_id: "123", email: "456")
 # => Strict::MethodReturnError
 ```
 
+`returns` validates the exact value produced by the method. It never coerces or replaces that value, and a successful call returns the same object to the caller.
+
 ### `Strict::Interface`
 
 ```rb

--- a/lib/strict/attribute.rb
+++ b/lib/strict/attribute.rb
@@ -2,6 +2,14 @@
 
 module Strict
   class Attribute < Declaration
+    class << self
+      private
+
+      def coercer_supported?(coercer)
+        super || coercer.equal?(true) || coercer.is_a?(Symbol) || coercer.respond_to?(:call)
+      end
+    end
+
     attr_reader :instance_variable
 
     def initialize(name:, validator:, default_generator:, coercer:)

--- a/lib/strict/attributes/dsl.rb
+++ b/lib/strict/attributes/dsl.rb
@@ -22,6 +22,10 @@ module Strict
 
       def strict_attribute(*, **)
         attribute = ::Strict::Attribute.make(*, **)
+        if __strict_dsl_internal_attributes.key?(attribute.name)
+          ::Kernel.raise ::ArgumentError, "Attribute #{attribute.name.inspect} is already declared"
+        end
+
         __strict_dsl_internal_attributes[attribute.name] = attribute
         nil
       end

--- a/lib/strict/attributes/generated_methods.rb
+++ b/lib/strict/attributes/generated_methods.rb
@@ -3,20 +3,47 @@
 module Strict
   module Attributes
     class GeneratedMethods < ::Module
-      def self.install_on(target, writable:)
-        target.define_singleton_method(:attributes) do |&block|
-          block ||= -> {}
-          inherited_attributes = respond_to?(:strict_attributes) ? strict_attributes : []
-          configuration = Strict::Attributes::Dsl.run(attributes: inherited_attributes, &block)
-          include Strict::Attributes::GeneratedMethods.new(configuration, writable: writable)
-          include Strict::Attributes::Instance
-          extend Strict::Attributes::Class
+      DECLARATION_MARKER = :@__strict_attributes_declared
+      private_constant :DECLARATION_MARKER
+
+      class << self
+        def install_on(target, writable:)
+          installation = ->(receiver, &definition) { install_attributes_on(receiver, writable, &definition) }
+          target.define_singleton_method(:attributes) do |&definition|
+            installation.call(self, &definition)
+          end
         end
+
+        private
+
+        # rubocop:disable Metrics/MethodLength
+        def install_attributes_on(target, writable, &definition)
+          if target.instance_variable_defined?(DECLARATION_MARKER)
+            raise ArgumentError, "Attributes are already declared for #{target}"
+          end
+
+          definition ||= -> {}
+          inherited_attributes = target.respond_to?(:strict_attributes) ? target.strict_attributes.to_a : []
+          configuration = Strict::Attributes::Dsl.run(attributes: inherited_attributes, &definition)
+          declared_attributes = configuration.attributes.drop(inherited_attributes.length)
+          generated_methods = new(
+            configuration,
+            writable: writable,
+            target: target,
+            declared_attributes: declared_attributes
+          )
+          target.instance_variable_set(DECLARATION_MARKER, true)
+          target.include(generated_methods)
+          target.include(Strict::Attributes::Instance)
+          target.extend(Strict::Attributes::Class)
+        end
+        # rubocop:enable Metrics/MethodLength
       end
 
-      def initialize(configuration, writable:)
+      def initialize(configuration, writable:, target:, declared_attributes:)
         super()
 
+        validate_collisions!(target, declared_attributes, writable: writable)
         const_set(Strict::Attributes::Class::CONSTANT, configuration)
         configuration.each do |attribute|
           define_reader(attribute)
@@ -25,6 +52,25 @@ module Strict
       end
 
       private
+
+      def validate_collisions!(target, attributes, writable:)
+        attributes.each do |attribute|
+          validate_method_available!(target, attribute.name)
+          validate_method_available!(target, :"#{attribute.name}=") if writable
+        end
+      end
+
+      def validate_method_available!(target, name)
+        return unless method_defined?(target, name) || method_defined?(Strict::Attributes::Instance, name)
+
+        raise ArgumentError, "Generated attribute method #{name.inspect} already exists for #{target}"
+      end
+
+      def method_defined?(owner, name)
+        owner.public_method_defined?(name) ||
+          owner.protected_method_defined?(name) ||
+          owner.private_method_defined?(name)
+      end
 
       def define_reader(attribute)
         storage_name = attribute.instance_variable.to_s.delete_prefix("@").to_sym

--- a/lib/strict/declaration.rb
+++ b/lib/strict/declaration.rb
@@ -3,6 +3,8 @@
 module Strict
   class Declaration
     NOT_PROVIDED = ::Object.new.freeze
+    DECLARATION_NAME = /\A[a-z_][a-zA-Z0-9_]*[!?]?\z/
+    private_constant :DECLARATION_NAME
 
     class << self
       def make(
@@ -11,9 +13,9 @@ module Strict
         coerce: validator.respond_to?(:coercer) ? validator.coercer : false,
         **defaults
       )
-        unless valid_defaults?(**defaults)
-          raise ArgumentError, "Only one of 'default', 'default_value', or 'default_generator' can be provided"
-        end
+        validate_name!(name)
+        validate_defaults!(**defaults)
+        validate_coercer!(coerce)
 
         new(
           name: name.to_sym,
@@ -25,12 +27,43 @@ module Strict
 
       private
 
+      def validate_name!(name)
+        supported_type = name.is_a?(::String) || name.is_a?(::Symbol)
+        return if supported_type && DECLARATION_NAME.match?(name.to_s)
+
+        raise ArgumentError, "Declaration name must be a supported String or Symbol, got #{name.inspect}"
+      end
+
+      def validate_defaults!(**defaults)
+        unless valid_defaults?(**defaults)
+          raise ArgumentError, "Only one of 'default', 'default_value', or 'default_generator' can be provided"
+        end
+
+        validate_default_generator!(**defaults)
+      end
+
       def valid_defaults?(default: NOT_PROVIDED, default_value: NOT_PROVIDED, default_generator: NOT_PROVIDED)
         defaults_provided = [default, default_value, default_generator].count do |default_option|
           !default_option.equal?(NOT_PROVIDED)
         end
 
         defaults_provided <= 1
+      end
+
+      def validate_default_generator!(default_generator: NOT_PROVIDED, **)
+        return if default_generator.equal?(NOT_PROVIDED) || default_generator.respond_to?(:call)
+
+        raise ArgumentError, "default_generator must be callable, got #{default_generator.inspect}"
+      end
+
+      def validate_coercer!(coercer)
+        return if coercer_supported?(coercer)
+
+        raise ArgumentError, "Unsupported coercer: #{coercer.inspect}"
+      end
+
+      def coercer_supported?(coercer)
+        coercer.equal?(false)
       end
 
       def make_default_generator(default: NOT_PROVIDED, default_value: NOT_PROVIDED, default_generator: NOT_PROVIDED)

--- a/lib/strict/methods/dsl.rb
+++ b/lib/strict/methods/dsl.rb
@@ -22,15 +22,23 @@ module Strict
       def initialize
         @__strict_dsl_internal_parameters = {}
         @__strict_dsl_internal_returns = ::Strict::Return.make
+        @__strict_dsl_internal_returns_declared = false
       end
 
       def returns(*, **)
+        ::Kernel.raise ::ArgumentError, "Return value is already declared" if @__strict_dsl_internal_returns_declared
+
         self.__strict_dsl_internal_returns = ::Strict::Return.make(*, **)
+        @__strict_dsl_internal_returns_declared = true
         nil
       end
 
       def strict_parameter(*, **)
         parameter = ::Strict::Parameter.make(*, **)
+        if __strict_dsl_internal_parameters.key?(parameter.name)
+          ::Kernel.raise ::ArgumentError, "Parameter #{parameter.name.inspect} is already declared"
+        end
+
         __strict_dsl_internal_parameters[parameter.name] = parameter
         nil
       end

--- a/lib/strict/methods/verifiable_method.rb
+++ b/lib/strict/methods/verifiable_method.rb
@@ -208,7 +208,6 @@ module Strict
       # rubocop:enable Metrics/AbcSize, Metrics/BlockLength, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
 
       def verify_returns!(value, configuration)
-        value = returns.coerce(value)
         violations = returns.violations(value, configuration)
         return if violations.empty?
 

--- a/lib/strict/parameter.rb
+++ b/lib/strict/parameter.rb
@@ -2,6 +2,14 @@
 
 module Strict
   class Parameter < Declaration
+    class << self
+      private
+
+      def coercer_supported?(coercer)
+        super || coercer.respond_to?(:call)
+      end
+    end
+
     def coerce(value)
       return value unless coercer
 

--- a/lib/strict/return.rb
+++ b/lib/strict/return.rb
@@ -3,16 +3,17 @@
 module Strict
   class Return
     class << self
-      def make(validator = Validators::Anything.instance, coerce: false)
-        new(validator: validator, coercer: coerce)
+      def make(validator = Validators::Anything.instance, **unsupported)
+        raise ArgumentError, "Unsupported return options: #{unsupported.keys.join(', ')}" if unsupported.any?
+
+        new(validator: validator)
       end
     end
 
-    attr_reader :validator, :coercer
+    attr_reader :validator
 
-    def initialize(validator:, coercer:)
+    def initialize(validator:)
       @validator = validator
-      @coercer = coercer
       @detailed_validator = DetailedValidator === validator
     end
 
@@ -26,12 +27,6 @@ module Strict
       return Validation::NONE if validator === value
 
       Validation.invalid(validator, value)
-    end
-
-    def coerce(value)
-      return value unless coercer
-
-      coercer.call(value)
     end
   end
 end

--- a/spec/strict/attribute_spec.rb
+++ b/spec/strict/attribute_spec.rb
@@ -95,6 +95,24 @@ RSpec.describe Strict::Attribute do
         described_class.make(:attr_name, default: 1, default_value: 1)
       end.to raise_error(ArgumentError)
     end
+
+    it "requires a supported declaration name" do
+      [nil, 1, "", :+, :"attr_name=", :"two words", :"attr[]"].each do |name|
+        expect { described_class.make(name) }.to raise_error(ArgumentError)
+      end
+    end
+
+    it "requires an explicit default generator to be callable" do
+      expect do
+        described_class.make(:attr_name, default_generator: "not callable")
+      end.to raise_error(ArgumentError)
+    end
+
+    it "requires a supported attribute coercer" do
+      [nil, 1, "coerce", Object.new].each do |coercer|
+        expect { described_class.make(:attr_name, coerce: coercer) }.to raise_error(ArgumentError)
+      end
+    end
   end
 
   describe "#valid?" do

--- a/spec/strict/attributes/dsl_spec.rb
+++ b/spec/strict/attributes/dsl_spec.rb
@@ -64,14 +64,21 @@ RSpec.describe Strict::Attributes::Dsl do
       expect(configuration.named!(:range_of).validator).to be_an_instance_of(Strict::Validators::RangeOf)
     end
 
-    it "allows overwriting attributes" do
-      configuration = described_class.run do
-        foo String
-        foo Integer
-      end
+    it "rejects duplicate attributes" do
+      expect do
+        described_class.run do
+          foo String
+          foo Integer
+        end
+      end.to raise_error(ArgumentError)
+    end
 
-      expect(configuration.map(&:name)).to eq(%i[foo])
-      expect(configuration.map(&:validator)).to eq([Integer])
+    it "rejects attributes inherited by the declaration" do
+      inherited = Strict::Attribute.make(:foo, String)
+
+      expect do
+        described_class.run(attributes: [inherited]) { foo Integer }
+      end.to raise_error(ArgumentError)
     end
 
     it "allows manually creating attributes" do

--- a/spec/strict/attributes/generated_methods_spec.rb
+++ b/spec/strict/attributes/generated_methods_spec.rb
@@ -23,4 +23,59 @@ RSpec.describe Strict::Attributes::GeneratedMethods do
     expect(value_owner.const_get(Strict::Attributes::Class::CONSTANT, false)).to be(value_class.strict_attributes)
     expect(object_owner.const_get(Strict::Attributes::Class::CONSTANT, false)).to be(object_class.strict_attributes)
   end
+
+  it "rejects a second attributes block on the same class" do
+    [Strict::Value, Strict::Object].each do |capability|
+      strict_class = Class.new do
+        include capability
+
+        attributes { nil }
+      end
+
+      expect do
+        strict_class.attributes { name String }
+      end.to raise_error(ArgumentError)
+    end
+  end
+
+  it "rejects generated readers that collide with existing or Strict methods" do
+    %i[class to_h pretty_print inspect hash eql? initialize public_send].each do |name|
+      expect do
+        Class.new do
+          include Strict::Value
+
+          attributes { strict_attribute name, String }
+        end
+      end.to raise_error(ArgumentError)
+    end
+  end
+
+  it "checks public, protected, and private reader collisions" do
+    %i[public_reader protected_reader private_reader].each do |name|
+      visibility = name.to_s.delete_suffix("_reader").to_sym
+
+      expect do
+        Class.new do
+          include Strict::Object
+
+          define_method(name) { nil }
+          send(visibility, name)
+          attributes { strict_attribute name, String }
+        end
+      end.to raise_error(ArgumentError)
+    end
+  end
+
+  it "rejects generated object writers that collide with existing methods" do
+    expect do
+      Class.new do
+        include Strict::Object
+
+        def name=(_value); end
+        private :name=
+
+        attributes { name String }
+      end
+    end.to raise_error(ArgumentError)
+  end
 end

--- a/spec/strict/methods/dsl_spec.rb
+++ b/spec/strict/methods/dsl_spec.rb
@@ -56,14 +56,13 @@ RSpec.describe Strict::Methods::Dsl do
       expect(configuration.returns.validator).to be_an_instance_of(Strict::Validators::Boolean)
     end
 
-    it "allows overwriting parameters" do
-      configuration = described_class.run do
-        foo String
-        foo Integer
-      end
-
-      expect(configuration.parameters.map(&:name)).to eq(%i[foo])
-      expect(configuration.parameters.map(&:validator)).to eq([Integer])
+    it "rejects duplicate parameters" do
+      expect do
+        described_class.run do
+          foo String
+          foo Integer
+        end
+      end.to raise_error(ArgumentError)
     end
 
     it "allows manually creating parameters" do
@@ -96,6 +95,15 @@ RSpec.describe Strict::Methods::Dsl do
     it "rejects return coercion" do
       expect do
         described_class.run { returns String, coerce: ->(value) { value.to_s } }
+      end.to raise_error(ArgumentError)
+    end
+
+    it "rejects repeated return declarations" do
+      expect do
+        described_class.run do
+          returns String
+          returns Integer
+        end
       end.to raise_error(ArgumentError)
     end
   end

--- a/spec/strict/methods/dsl_spec.rb
+++ b/spec/strict/methods/dsl_spec.rb
@@ -92,5 +92,11 @@ RSpec.describe Strict::Methods::Dsl do
 
       expect(configuration.returns.validator).to be_an_instance_of(Strict::Validators::Anything)
     end
+
+    it "rejects return coercion" do
+      expect do
+        described_class.run { returns String, coerce: ->(value) { value.to_s } }
+      end.to raise_error(ArgumentError)
+    end
   end
 end

--- a/spec/strict/parameter_spec.rb
+++ b/spec/strict/parameter_spec.rb
@@ -89,6 +89,12 @@ RSpec.describe Strict::Parameter do
         described_class.make(:attr_name, default: 1, default_value: 1)
       end.to raise_error(ArgumentError)
     end
+
+    it "requires a supported parameter coercer" do
+      [nil, true, :coerce, 1, Object.new].each do |coercer|
+        expect { described_class.make(:attr_name, coerce: coercer) }.to raise_error(ArgumentError)
+      end
+    end
   end
 
   describe "#valid?" do
@@ -150,22 +156,6 @@ RSpec.describe Strict::Parameter do
       parameter = described_class.make(:attr_name, coerce: false)
 
       expect(parameter.coerce("value")).to eq("value")
-    end
-
-    it "does not support .coerce_attr_name coercion" do
-      parameter = described_class.make(:attr_name, coerce: true)
-
-      expect do
-        parameter.coerce("value")
-      end.to raise_error(NoMethodError)
-    end
-
-    it "does not support coercion methods is passed" do
-      parameter = described_class.make(:attr_name, coerce: :some_method)
-
-      expect do
-        parameter.coerce("value")
-      end.to raise_error(NoMethodError)
     end
 
     it "calls the callable if one is passed" do

--- a/spec/strict/return_spec.rb
+++ b/spec/strict/return_spec.rb
@@ -4,18 +4,10 @@ require "spec_helper"
 
 RSpec.describe Strict::Return do
   describe ".make" do
-    it "has defaults for the validator and coercion" do
+    it "has a default validator" do
       returns = described_class.make
 
       expect(returns.validator).to eq(Strict::Validators::Anything.instance)
-      expect(returns.coercer).to be_falsey
-    end
-
-    it "accepts a combination of all arguments" do
-      returns = described_class.make(Strict::Validators::Boolean.instance, coerce: ->(value) { value + 1 })
-
-      expect(returns.validator).to eq(Strict::Validators::Boolean.instance)
-      expect(returns.coercer).to be_truthy
     end
 
     it "accepts a validator" do
@@ -24,10 +16,10 @@ RSpec.describe Strict::Return do
       expect(returns.validator).to eq(Strict::Validators::Boolean.instance)
     end
 
-    it "accepts a coerce value" do
-      returns = described_class.make(coerce: ->(value) { value + 1 })
-
-      expect(returns.coercer).to be_truthy
+    it "does not accept coercion" do
+      expect do
+        described_class.make(coerce: ->(value) { value + 1 })
+      end.to raise_error(ArgumentError)
     end
 
     it "does not accept a value for 'default'" do
@@ -97,36 +89,6 @@ RSpec.describe Strict::Return do
         expect(returns.valid?(nil)).to be(false)
         expect(validator.called).to be(true)
       end
-    end
-  end
-
-  describe "#coerce" do
-    it "returns the value if coercion is not enabled" do
-      returns = described_class.make(coerce: false)
-
-      expect(returns.coerce("value")).to eq("value")
-    end
-
-    it "does not support .coerce_attr_name coercion" do
-      returns = described_class.make(coerce: true)
-
-      expect do
-        returns.coerce("value")
-      end.to raise_error(NoMethodError)
-    end
-
-    it "does not support coercion methods is passed" do
-      returns = described_class.make(coerce: :some_method)
-
-      expect do
-        returns.coerce("value")
-      end.to raise_error(NoMethodError)
-    end
-
-    it "calls the callable if one is passed" do
-      returns = described_class.make(coerce: ->(value) { "coerced #{value}" })
-
-      expect(returns.coerce("value")).to eq("coerced value")
     end
   end
 end

--- a/spec/strict/strict_public_api_spec.rb
+++ b/spec/strict/strict_public_api_spec.rb
@@ -220,7 +220,6 @@ RSpec.describe Strict do
       parent_class = Class.new do
         include Strict::Object
 
-        def self.coerce_automatic(value) = "parent #{value}"
         def self.symbolic(value) = "parent #{value}"
 
         attributes do

--- a/spec/strict/strict_public_api_spec.rb
+++ b/spec/strict/strict_public_api_spec.rb
@@ -123,6 +123,47 @@ RSpec.describe Strict do
       expect(value.value!).to eq(:dangerous)
       expect(value.to_h).to eq(value: "plain", value?: 1, value!: :dangerous)
     end
+
+    it "rejects invalid attribute declarations before installing methods" do
+      invalid_declarations = [
+        -> { attributes { strict_attribute :"name=", String } },
+        -> { attributes { name String, default_generator: "not callable" } },
+        -> { attributes { name String, coerce: Object.new } },
+        lambda do
+          attributes do
+            name String
+            name Integer
+          end
+        end,
+        -> { attributes { to_h Hash } }
+      ]
+
+      invalid_declarations.each do |declaration|
+        expect do
+          Class.new do
+            include Strict::Value
+
+            class_exec(&declaration)
+          end
+        end.to raise_error(ArgumentError)
+      end
+    end
+
+    it "rejects repeated and inherited attribute declarations" do
+      parent_class = Class.new do
+        include Strict::Value
+
+        attributes { name String }
+      end
+
+      expect do
+        Class.new(parent_class) { attributes { name String } }
+      end.to raise_error(ArgumentError)
+
+      expect do
+        parent_class.attributes { employee_id String }
+      end.to raise_error(ArgumentError)
+    end
   end
 
   describe "objects" do
@@ -199,6 +240,18 @@ RSpec.describe Strict do
       expect(object.to_h).to eq(automatic: "child assigned", symbolic: "child assigned")
     end
 
+    it "rejects an attribute whose generated writer already exists" do
+      expect do
+        Class.new do
+          include Strict::Object
+
+          def name=(_value); end
+
+          attributes { name String }
+        end
+      end.to raise_error(ArgumentError)
+    end
+
     it "coerces before sampling each assignment once" do
       validations = []
       coercions = []
@@ -254,7 +307,7 @@ RSpec.describe Strict do
           anything Anything()
           array ArrayOf(Integer)
           boolean Boolean()
-          hash HashOf(Symbol => Integer)
+          hash_value HashOf(Symbol => Integer)
           range RangeOf(Integer)
           custom custom_validator
           coerced_array ArrayOf(String), coerce: ToArray(with: ->(value) { value.to_s })
@@ -270,7 +323,7 @@ RSpec.describe Strict do
         anything: Object.new,
         array: [1, 2],
         boolean: false,
-        hash: { one: 1 },
+        hash_value: { one: 1 },
         range: 1..3,
         custom: :custom,
         coerced_array: [1, 2],
@@ -286,7 +339,7 @@ RSpec.describe Strict do
           anything: nil,
           array: [],
           boolean: true,
-          hash: {},
+          hash_value: {},
           range: 1..3,
           custom: :custom,
           coerced_array: [],
@@ -462,6 +515,36 @@ RSpec.describe Strict do
           sig { returns String, coerce: ->(value) { value.to_s } }
         end
       end.to raise_error(ArgumentError)
+    end
+
+    it "rejects invalid and duplicate signature declarations" do
+      invalid_signatures = [
+        lambda do
+          sig do
+            value Integer
+            value String
+          end
+        end,
+        lambda do
+          sig do
+            returns String
+            returns Integer
+          end
+        end,
+        -> { sig { value Integer, coerce: true } },
+        -> { sig { value Integer, default_generator: 1 } },
+        -> { sig { strict_parameter :"value=", String } }
+      ]
+
+      invalid_signatures.each do |signature|
+        expect do
+          Class.new do
+            include Strict::Method
+
+            class_exec(&signature)
+          end
+        end.to raise_error(ArgumentError)
+      end
     end
   end
 

--- a/spec/strict/strict_public_api_spec.rb
+++ b/spec/strict/strict_public_api_spec.rb
@@ -441,6 +441,28 @@ RSpec.describe Strict do
       expect { inherited_class.call("1") }.to raise_error(Strict::MethodCallError)
       expect(overridden_class.call("1")).to eq("1")
     end
+
+    it "validates and preserves the exact returned object" do
+      returned = Object.new
+      method_class = Class.new do
+        include Strict::Method
+
+        sig { returns Object }
+        define_method(:call) { returned }
+      end
+
+      expect(method_class.new.call).to be(returned)
+    end
+
+    it "rejects return coercion when declaring the signature" do
+      expect do
+        Class.new do
+          include Strict::Method
+
+          sig { returns String, coerce: ->(value) { value.to_s } }
+        end
+      end.to raise_error(ArgumentError)
+    end
   end
 
   describe "interfaces" do
@@ -692,17 +714,21 @@ RSpec.describe Strict do
       }
     end
 
-    it "exposes the invalid return value" do
+    it "exposes the original invalid return value and violation" do
+      returned = Object.new
       method_class = Class.new do
         include Strict::Method
 
         sig { returns String }
-        def call = 1
+        define_method(:call) { returned }
       end
 
       expect do
         method_class.new.call
-      end.to raise_error(Strict::MethodReturnError) { |error| expect(error.value).to eq(1) }
+      end.to raise_error(Strict::MethodReturnError) { |error|
+        expect(error.value).to be(returned)
+        expect(error.violations.fetch(0).value).to be(returned)
+      }
     end
   end
 end

--- a/spec/strict/union_spec.rb
+++ b/spec/strict/union_spec.rb
@@ -346,6 +346,35 @@ RSpec.describe Strict::Union do
           end
         end
       end
-    end.to raise_error(ArgumentError, /cannot redeclare discriminator :kind/)
+    end.to raise_error(ArgumentError)
+  end
+
+  it "rejects variant attributes that duplicate shared attributes" do
+    expect do
+      Class.new do
+        include Strict::Union
+
+        discriminator :kind
+        attributes { request_id String }
+        variant :invalid do
+          attributes { request_id Integer }
+        end
+      end
+    end.to raise_error(ArgumentError)
+  end
+
+  it "rejects variant attributes that collide with variant methods" do
+    expect do
+      Class.new do
+        include Strict::Union
+
+        discriminator :kind
+        variant :invalid do
+          def result = "method"
+
+          attributes { result String }
+        end
+      end
+    end.to raise_error(ArgumentError)
   end
 end


### PR DESCRIPTION
## Summary

- make `returns` validate-only so signed methods return the exact object they produced, while errors and violations retain the original invalid value
- reject unsupported return options, malformed names, invalid default generators and coercer forms, duplicate parameters or attributes, repeated returns, and repeated class attribute blocks at declaration time
- reject generated reader and writer collisions across public, protected, private, inherited, Ruby, and Strict capability methods, including union variant declarations
- document the declaration-time `ArgumentError` policy and validate-only return contract

## Compatibility impact

This intentionally breaks previously undocumented behavior that silently replaced duplicate declarations, accepted pathological generated method names, installed method collisions, or configured return coercion. These declarations now fail immediately with `ArgumentError`; exact messages remain non-contractual.

Attribute coercers selected with `true` or a symbol are still resolved at runtime, so subclasses can provide or override the class methods. Existing automatic validator coercion on `main` is also preserved.

## Verification

- `bundle exec rake`
  - 315 examples, 0 failures
  - 89 files inspected by RuboCop, no offenses
  - RBS signatures validated
