### PR TITLE
Prevent Strict internals from leaking into consumer namespaces

### DIFF
--- a/lib/strict/attributes/class.rb
+++ b/lib/strict/attributes/class.rb
@@ -3,12 +3,6 @@
 module Strict
   module Attributes
     module Class
-      CONSTANT = :STRICT_INTERNAL_ATTRIBUTES_CONFIGURATION__
-
-      def strict_attributes
-        self::STRICT_INTERNAL_ATTRIBUTES_CONFIGURATION__
-      end
-
       def coercer
         Coercer.new(self)
       end

--- a/lib/strict/attributes/generated_methods.rb
+++ b/lib/strict/attributes/generated_methods.rb
@@ -33,8 +33,8 @@ module Strict
             declared_attributes: declared_attributes
           )
           target.instance_variable_set(DECLARATION_MARKER, true)
-          target.include(generated_methods)
-          target.include(Strict::Attributes::Instance)
+          target.include(Strict::Attributes::Instance, generated_methods)
+          target.define_singleton_method(:strict_attributes) { configuration }
           target.extend(Strict::Attributes::Class)
         end
         # rubocop:enable Metrics/MethodLength
@@ -44,7 +44,6 @@ module Strict
         super()
 
         validate_collisions!(target, declared_attributes, writable: writable)
-        const_set(Strict::Attributes::Class::CONSTANT, configuration)
         configuration.each do |attribute|
           define_reader(attribute)
           define_writer(attribute) if writable

--- a/lib/strict/interface.rb
+++ b/lib/strict/interface.rb
@@ -44,5 +44,7 @@ module Strict
         @strict_interface_conformance ||= Interfaces::Conformance.new(self)
       end
     end
+
+    private_constant :ClassMethods
   end
 end

--- a/lib/strict/method.rb
+++ b/lib/strict/method.rb
@@ -85,5 +85,7 @@ module Strict
         end
       end
     end
+
+    private_constant :ClassMethods
   end
 end

--- a/lib/strict/union.rb
+++ b/lib/strict/union.rb
@@ -164,5 +164,7 @@ module Strict
         raise TypeError, "cannot instantiate union #{self.class} directly; instantiate one of its variants"
       end
     end
+
+    private_constant :ClassMethods, :Instance
   end
 end

--- a/spec/strict/attributes/class_spec.rb
+++ b/spec/strict/attributes/class_spec.rb
@@ -3,14 +3,12 @@
 require "spec_helper"
 
 RSpec.describe Strict::Attributes::Class do
-  it "aligns the constant with the lookup method" do
-    configured_class = described_class
-    mod = Module.new do
-      const_set(configured_class::CONSTANT, "config value")
+  it "builds a coercer for the extended class" do
+    attributes_class = Class.new
+    attributes_class.extend(described_class)
+    coercer = attributes_class.coercer
 
-      extend configured_class
-    end
-
-    expect(mod.strict_attributes).to eq("config value")
+    expect(coercer).to be_a(Strict::Attributes::Coercer)
+    expect(coercer.attributes_class).to be(attributes_class)
   end
 end

--- a/spec/strict/attributes/generated_methods_spec.rb
+++ b/spec/strict/attributes/generated_methods_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 RSpec.describe Strict::Attributes::GeneratedMethods do
-  it "owns generated methods and their configurations for values and objects" do
+  it "owns generated methods for values and objects" do
     value_class = Class.new do
       include Strict::Value
 
@@ -20,8 +20,6 @@ RSpec.describe Strict::Attributes::GeneratedMethods do
     expect(value_owner).to be_a(described_class)
     expect(object_owner).to be_a(described_class)
     expect(object_class.instance_method(:name=).owner).to be(object_owner)
-    expect(value_owner.const_get(Strict::Attributes::Class::CONSTANT, false)).to be(value_class.strict_attributes)
-    expect(object_owner.const_get(Strict::Attributes::Class::CONSTANT, false)).to be(object_class.strict_attributes)
   end
 
   it "rejects a second attributes block on the same class" do

--- a/spec/strict_spec.rb
+++ b/spec/strict_spec.rb
@@ -36,4 +36,40 @@ RSpec.describe Strict do
     end
     expect(described_class.configuration.sample_rate).to eq(1)
   end
+
+  it "does not expose implementation constants through consumer classes" do
+    value_class = Class.new do
+      include Strict::Value
+
+      attributes { nil }
+    end
+    object_class = Class.new do
+      include Strict::Object
+
+      attributes { nil }
+    end
+    method_class = Class.new { include Strict::Method }
+    interface_class = Class.new { include Strict::Interface }
+    union_class = Class.new { include Strict::Union }
+
+    expect(value_class.constants).not_to include(:STRICT_INTERNAL_ATTRIBUTES_CONFIGURATION__)
+    expect(object_class.constants).not_to include(:STRICT_INTERNAL_ATTRIBUTES_CONFIGURATION__)
+    expect(method_class.constants).not_to include(:ClassMethods)
+    expect(interface_class.constants).not_to include(:ClassMethods)
+    expect(union_class.constants).not_to include(:ClassMethods, :Instance)
+  end
+
+  it "does not reserve a configuration constant on value and object classes" do
+    [Strict::Value, Strict::Object].each do |capability|
+      strict_class = Class.new do
+        const_set(:STRICT_INTERNAL_ATTRIBUTES_CONFIGURATION__, :application_value)
+        include capability
+
+        attributes { name String }
+      end
+
+      expect(strict_class.const_get(:STRICT_INTERNAL_ATTRIBUTES_CONFIGURATION__, false)).to eq(:application_value)
+      expect(strict_class.new(name: "example").name).to eq("example")
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- store attribute introspection configuration without an inherited implementation constant
- hide capability implementation constants from consumer classes
- cover namespace isolation and application constant collisions

## Verification
- `bundle exec rake`
