### PR TITLE
Allow attributes to override inherited methods

### DIFF
--- a/API.md
+++ b/API.md
@@ -20,7 +20,7 @@ The former `extend Strict::Method` and `extend Strict::Interface` forms are not 
 
 `Strict::Value` and `Strict::Object` add an `attributes` declaration block. Each declaration accepts an attribute name, an optional validator, `coerce:`, and one of `default:`, `default_value:`, or `default_generator:`.
 
-Attribute names must be strings or symbols in the supported identifier shape: a lowercase ASCII letter or underscore, followed by ASCII letters, digits, or underscores, with one optional trailing `?` or `!`. Ruby reserved words use `strict_attribute`, for example `strict_attribute :if`. Empty names, operators, setters, and other method-name forms are rejected. Each distinct supported name has independent backing storage, including names that differ only by a trailing `?` or `!`. A mutable object's punctuation writer can be called with `public_send`, for example `object.public_send(:"active?=", false)`.
+Attribute names must be strings or symbols in the supported identifier shape: a lowercase ASCII letter or underscore, followed by ASCII letters, digits, or underscores, with one optional trailing `?` or `!`. Use `strict_attribute` when a name is a Ruby reserved word or already resolves to a method inside the declaration block, for example `strict_attribute :if` or `strict_attribute :format`. Empty names, operators, setters, and other method-name forms are rejected. Each distinct supported name has independent backing storage, including names that differ only by a trailing `?` or `!`. A mutable object's punctuation writer can be called with `public_send`, for example `object.public_send(:"active?=", false)`.
 
 Both capabilities provide:
 
@@ -42,7 +42,9 @@ Both capabilities provide:
 
 A class can execute at most one `attributes` block, and an empty block counts as that one block. A subclass inherits its parent's attributes and can execute one additive `attributes` block without changing the parent. An attribute cannot duplicate another attribute in the same block or an inherited attribute.
 
-Before it installs generated methods, Strict rejects an attribute whose reader would collide with any existing public, protected, or private instance method. This includes methods supplied by Ruby and Strict, such as `class`, `to_h`, `inspect`, `hash`, `eql?`, `initialize`, `pretty_print`, and `public_send`. `Strict::Object` applies the same check to its generated writer. Strict does not police methods defined after the `attributes` block; later overrides remain unsupported. Duplicate attributes, repeated blocks, generated-method collisions, and invalid names or declaration options raise `ArgumentError` at declaration time.
+Before it installs generated methods, Strict rejects an attribute whose reader would collide with a public, protected, or private instance method defined directly on the declaring class. It also rejects methods reserved by `BasicObject`, the active Strict capability, or Strict's generated implementation, including `class`, `to_h`, `inspect`, `hash`, `eql?`, `initialize`, `pretty_print`, and `public_send`. `Strict::Object` applies the same checks to its generated writer.
+
+An attribute can override an inherited public, protected, or private method from a superclass or a non-Strict included module. The generated reader or writer is public and replaces the inherited behavior; it does not wrap or validate calls to the inherited method. Strict does not police methods defined after the `attributes` block; later overrides remain unsupported. Duplicate attributes, repeated blocks, prohibited generated-method collisions, and invalid names or declaration options raise `ArgumentError` at declaration time.
 
 #### Attribute introspection
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 - Standardize all four capabilities on `include`: `Strict::Value`, `Strict::Object`, `Strict::Method`, and `Strict::Interface`. The legacy `extend Strict::Method` and `extend Strict::Interface` forms are outside the supported next-major API.
 - Make signed method returns validate-only. `returns` rejects coercion options, validates the original result, and preserves its identity for the caller.
-- Reject malformed, duplicate, repeated, or method-colliding attribute and signature declarations with `ArgumentError` instead of silently replacing declarations or installing pathological methods.
+- Reject malformed, duplicate, or repeated attribute and signature declarations, plus same-class or Strict/core-reserved generated attribute method collisions, with `ArgumentError` instead of silently replacing declarations or installing pathological methods.
 
 ### Changed
 
@@ -29,6 +29,7 @@
 - Propagate default coercion through `ArrayOf` elements and `HashOf` keys and values.
 - Keep Strict configuration overrides in isolated internal execution-context storage to avoid collisions with application keys.
 - Generate attribute readers and writers through one shared implementation, with mutable writers bound directly to their declarations.
+- Allow generated attribute readers and writers to override inherited public, protected, and private methods while continuing to reject same-class and Strict/core-reserved collisions.
 - Return exact `Strict::Value` and `Strict::Object` instances unchanged from their class coercers while continuing to convert subclass instances.
 - Validate declaration names, explicit default generators, and capability-specific coercer forms before installing attributes or signatures.
 

--- a/lib/strict/attributes/generated_methods.rb
+++ b/lib/strict/attributes/generated_methods.rb
@@ -4,7 +4,8 @@ module Strict
   module Attributes
     class GeneratedMethods < ::Module
       DECLARATION_MARKER = :@__strict_attributes_declared
-      private_constant :DECLARATION_MARKER
+      RESERVED_METHODS = %i[class eql? hash instance_variable_set public_send raise].freeze
+      private_constant :DECLARATION_MARKER, :RESERVED_METHODS
 
       class << self
         def install_on(target, writable:)
@@ -54,21 +55,29 @@ module Strict
 
       def validate_collisions!(target, attributes, writable:)
         attributes.each do |attribute|
-          validate_method_available!(target, attribute.name)
-          validate_method_available!(target, :"#{attribute.name}=") if writable
+          validate_method_available!(target, attribute.name, writable: writable)
+          validate_method_available!(target, :"#{attribute.name}=", writable: writable) if writable
         end
       end
 
-      def validate_method_available!(target, name)
-        return unless method_defined?(target, name) || method_defined?(Strict::Attributes::Instance, name)
+      def validate_method_available!(target, name, writable:)
+        return unless method_reserved?(target, name, writable: writable)
 
         raise ArgumentError, "Generated attribute method #{name.inspect} already exists for #{target}"
       end
 
-      def method_defined?(owner, name)
-        owner.public_method_defined?(name) ||
-          owner.protected_method_defined?(name) ||
-          owner.private_method_defined?(name)
+      def method_reserved?(target, name, writable:)
+        method_defined_directly?(target, name) ||
+          method_defined_directly?(Strict::Attributes::Instance, name) ||
+          (!writable && method_defined_directly?(Strict::Value, name)) ||
+          method_defined_directly?(BasicObject, name) ||
+          RESERVED_METHODS.include?(name)
+      end
+
+      def method_defined_directly?(owner, name)
+        owner.public_method_defined?(name, false) ||
+          owner.protected_method_defined?(name, false) ||
+          owner.private_method_defined?(name, false)
       end
 
       def define_reader(attribute)

--- a/spec/strict/attributes/generated_methods_spec.rb
+++ b/spec/strict/attributes/generated_methods_spec.rb
@@ -36,8 +36,58 @@ RSpec.describe Strict::Attributes::GeneratedMethods do
     end
   end
 
+  it "allows generated readers to override inherited methods" do
+    parent_class = Class.new do
+      def tag(*) = "inherited tag"
+
+      def theme = "inherited theme"
+      protected :theme
+    end
+    value_class = Class.new(parent_class) do
+      include Strict::Value
+
+      attributes do
+        tag AnyOf("h1", "h2")
+        theme String
+        strict_attribute :format, String
+        strict_attribute :system, String
+        strict_attribute :fork, String
+      end
+    end
+    value = value_class.new(tag: "h1", theme: "dark", format: "short", system: "metric", fork: "main")
+
+    expect(value.to_h).to eq(tag: "h1", theme: "dark", format: "short", system: "metric", fork: "main")
+    expect(value).to respond_to(:theme, :format, :system, :fork)
+    expect do
+      value_class.new(tag: "div", theme: "dark", format: "short", system: "metric", fork: "main")
+    end.to raise_error(Strict::InitializationError)
+  end
+
+  it "allows generated accessors to override inherited methods" do
+    parent_class = Class.new do
+      attr_accessor :status
+      private :status=
+    end
+    object_class = Class.new(parent_class) do
+      include Strict::Object
+
+      attributes { status String }
+    end
+    object = object_class.new(status: "pending")
+
+    object.status = "complete"
+
+    expect(object.status).to eq("complete")
+    expect do
+      object.status = :invalid
+    end.to raise_error(Strict::AssignmentError)
+  end
+
   it "rejects generated readers that collide with existing or Strict methods" do
-    %i[class to_h pretty_print inspect hash eql? initialize public_send].each do |name|
+    %i[
+      __send__ class deconstruct_keys eql? hash initialize instance_variable_set inspect method_missing pretty_print
+      public_send raise to_h with
+    ].each do |name|
       expect do
         Class.new do
           include Strict::Value


### PR DESCRIPTION
## Summary

- allow generated attribute readers and writers to override inherited public, protected, and private methods
- continue rejecting same-class and Strict/core-reserved method collisions
- document that inherited behavior is replaced and that Kernel method names use `strict_attribute`

## Verification

- `bundle exec rake`
  - 317 examples, 0 failures
  - 89 files inspected by RuboCop, no offenses
  - RBS signatures validated
