### PR TITLE
Add override-safe attribute serialization

### DIFF
--- a/API.md
+++ b/API.md
@@ -28,6 +28,7 @@ Both capabilities provide:
 - declared readers;
 - coercion before validation;
 - `to_h`, with symbol keys in declaration order;
+- `as_json(options = nil)`, which applies Active Support's hash serialization when available and otherwise returns declared attributes with symbol keys in declaration order;
 - a meaningful `inspect` and pretty-print representation, without a fixed formatting contract;
 - class methods `strict_attributes` and `coercer`.
 
@@ -42,7 +43,7 @@ Both capabilities provide:
 
 A class can execute at most one `attributes` block, and an empty block counts as that one block. A subclass inherits its parent's attributes and can execute one additive `attributes` block without changing the parent. An attribute cannot duplicate another attribute in the same block or an inherited attribute.
 
-Before it installs generated methods, Strict rejects an attribute whose reader would collide with a public, protected, or private instance method defined directly on the declaring class. It also rejects methods reserved by `BasicObject`, the active Strict capability, or Strict's generated implementation, including `class`, `to_h`, `inspect`, `hash`, `eql?`, `initialize`, `pretty_print`, and `public_send`. `Strict::Object` applies the same checks to its generated writer.
+Before it installs generated methods, Strict rejects an attribute whose reader would collide with a public, protected, or private instance method defined directly on the declaring class. It also rejects methods reserved by `BasicObject`, the active Strict capability, or Strict's generated implementation, including `as_json`, `class`, `to_h`, `inspect`, `hash`, `eql?`, `initialize`, `pretty_print`, and `public_send`. `Strict::Object` applies the same checks to its generated writer.
 
 An attribute can override an inherited public, protected, or private method from a superclass or a non-Strict included module. The generated reader or writer is public and replaces the inherited behavior; it does not wrap or validate calls to the inherited method. Strict does not police methods defined after the `attributes` block; later overrides remain unsupported. Duplicate attributes, repeated blocks, prohibited generated-method collisions, and invalid names or declaration options raise `ArgumentError` at declaration time.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Add structured validation violations with paths, codes, rejected values, and validators for assignment, initialization, signed method calls, and returns, plus an optional detailed-validator protocol for custom nested failures.
 - Add opt-in RSpec matchers, verifying doubles, and nested matcher placeholders for Strict values and validations.
 - Add `implemented_by?` and `verify_implementation!` to check interface adapters without constructing an interface.
+- Add Rails-compatible `as_json` serialization for values, objects, and union variants.
 
 ### Breaking changes
 

--- a/lib/strict/attributes/instance.rb
+++ b/lib/strict/attributes/instance.rb
@@ -3,6 +3,12 @@
 module Strict
   module Attributes
     module Instance
+      def self.attribute_values(instance)
+        instance.class.strict_attributes.to_h do |attribute|
+          [attribute.name, instance.public_send(attribute.name)]
+        end
+      end
+
       # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
       def initialize(**attributes)
         initializable_class = self.class
@@ -53,16 +59,13 @@ module Strict
       # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
 
       def to_h
-        values = {}
-        self.class.strict_attributes.each do |attribute|
-          values[attribute.name] = public_send(attribute.name)
-        end
-        values
+        Instance.attribute_values(self)
       end
 
       def inspect
         if self.class.strict_attributes.any?
-          "#<#{self.class} #{to_h.map { |key, value| "#{key}=#{value.inspect}" }.join(' ')}>"
+          attributes = Instance.attribute_values(self)
+          "#<#{self.class} #{attributes.map { |key, value| "#{key}=#{value.inspect}" }.join(' ')}>"
         else
           "#<#{self.class}>"
         end
@@ -70,7 +73,7 @@ module Strict
 
       def pretty_print(pp)
         pp.object_group(self) do
-          to_h.each do |key, value|
+          Instance.attribute_values(self).each do |key, value|
             pp.breakable
             pp.text("#{key}=")
             pp.pp(value)

--- a/lib/strict/attributes/instance.rb
+++ b/lib/strict/attributes/instance.rb
@@ -62,6 +62,11 @@ module Strict
         Instance.attribute_values(self)
       end
 
+      def as_json(options = nil)
+        attributes = Instance.attribute_values(self)
+        attributes.respond_to?(:as_json) ? attributes.as_json(options) : attributes
+      end
+
       def inspect
         if self.class.strict_attributes.any?
           attributes = Instance.attribute_values(self)

--- a/lib/strict/value.rb
+++ b/lib/strict/value.rb
@@ -7,11 +7,11 @@ module Strict
     end
 
     def with(**attributes)
-      self.class.new(**to_h, **attributes)
+      self.class.new(**Attributes::Instance.attribute_values(self), **attributes)
     end
 
     def deconstruct_keys(keys)
-      attributes = to_h
+      attributes = Attributes::Instance.attribute_values(self)
       keys ? attributes.slice(*keys) : attributes
     end
 

--- a/sig/strict.rbs
+++ b/sig/strict.rbs
@@ -23,6 +23,7 @@ module Strict
 
   interface _AttributesInstance
     def to_h: () -> Hash[Symbol, untyped]
+    def as_json: (?untyped options) -> Hash[Symbol | String, untyped]
     def inspect: () -> String
     def pretty_print: (untyped printer) -> untyped
   end

--- a/spec/strict/attributes/generated_methods_spec.rb
+++ b/spec/strict/attributes/generated_methods_spec.rb
@@ -85,8 +85,8 @@ RSpec.describe Strict::Attributes::GeneratedMethods do
 
   it "rejects generated readers that collide with existing or Strict methods" do
     %i[
-      __send__ class deconstruct_keys eql? hash initialize instance_variable_set inspect method_missing pretty_print
-      public_send raise to_h with
+      __send__ as_json class deconstruct_keys eql? hash initialize instance_variable_set inspect method_missing
+      pretty_print public_send raise to_h with
     ].each do |name|
       expect do
         Class.new do

--- a/spec/strict/strict_public_api_spec.rb
+++ b/spec/strict/strict_public_api_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Strict do
       value = value_class.new(**attributes)
       equal_value = value_class.new(**attributes)
 
-      expect(value.to_h).to eq(
+      expected_attributes = {
         **attributes,
         count: 1,
         symbol_coerced: "2",
@@ -63,7 +63,9 @@ RSpec.describe Strict do
         generated_default: 1,
         callable_value: callable_value,
         explicit_generator: "generated"
-      )
+      }
+      expect(value.to_h).to eq(expected_attributes)
+      expect(value.as_json).to eq(expected_attributes)
       expect(value.public_send(:if)).to eq("yes")
       expect(value.active?).to be(true)
       expect(value).to eq(equal_value)
@@ -135,6 +137,7 @@ RSpec.describe Strict do
             name Integer
           end
         end,
+        -> { attributes { as_json Hash } },
         -> { attributes { to_h Hash } }
       ]
 

--- a/spec/strict/value_spec.rb
+++ b/spec/strict/value_spec.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "open3"
 require "spec_helper"
 
 RSpec.describe Strict::Value do
@@ -143,6 +144,50 @@ RSpec.describe Strict::Value do
     instance = build(:value)
 
     expect(instance.to_h).to eq(foo: 1, bar: "2", baz: "3")
+  end
+
+  it "turns into a JSON representation of its attributes" do
+    instance = build(:value)
+
+    expect(instance.as_json).to eq(foo: 1, bar: "2", baz: "3")
+  end
+
+  it "uses Active Support's hash serialization when it is available" do
+    lib = File.expand_path("../../lib", __dir__)
+    script = <<~'RUBY'
+      require "active_support"
+      require "active_support/json"
+      require "active_support/core_ext/object/json"
+      require "strict"
+
+      value_class = Class.new do
+        include Strict::Value
+
+        attributes do
+          occurred_at Anything()
+          metadata Hash
+          secret String
+        end
+
+        def to_h = { overridden: true }
+      end
+      value = value_class.new(
+        occurred_at: Time.utc(2026, 8, 21),
+        metadata: { source: :api },
+        secret: "hidden"
+      )
+      expected = {
+        "occurred_at" => "2026-08-21T00:00:00.000Z",
+        "metadata" => { "source" => "api" }
+      }
+      actual = value.as_json(except: :secret)
+      abort "expected #{expected.inspect}, got #{actual.inspect}" unless actual == expected
+    RUBY
+
+    output, status = Open3.capture2e(RbConfig.ruby, "-I#{lib}", "-e", script)
+
+    expect(output).to be_empty
+    expect(status).to be_success
   end
 
   it "does not use an overridden hash conversion for its own behavior" do

--- a/spec/strict/value_spec.rb
+++ b/spec/strict/value_spec.rb
@@ -145,6 +145,25 @@ RSpec.describe Strict::Value do
     expect(instance.to_h).to eq(foo: 1, bar: "2", baz: "3")
   end
 
+  it "does not use an overridden hash conversion for its own behavior" do
+    instance = build(:value)
+    instance.define_singleton_method(:to_h) { { overridden: true } }
+    output = StringIO.new
+
+    PP.pp(instance, output, 5)
+
+    expect(instance.to_h).to eq(overridden: true)
+    expect(instance.with(foo: 2)).to eq(build(:value, foo: 2))
+    expect(instance.deconstruct_keys(nil)).to eq(foo: 1, bar: "2", baz: "3")
+    expect(instance.inspect).to eq("#<ValueClass foo=1 bar=\"2\" baz=\"3\">")
+    expect(output.string).to eq(<<~OUTPUT)
+      #<ValueClass
+       foo=1
+       bar="2"
+       baz="3">
+    OUTPUT
+  end
+
   it "deconstructs attributes for pattern matching" do
     instance = build(:value)
 


### PR DESCRIPTION
## Summary

- derive Strict's internal value behavior from declared readers instead of user-overridable `to_h`
- add Rails-compatible `as_json` support without requiring Active Support at runtime
- document and type the new serialization API

## Verification

- `bundle exec rake`
