### PR TITLE
Restore conventional attribute backing ivars

### DIFF
--- a/API.md
+++ b/API.md
@@ -20,7 +20,7 @@ The former `extend Strict::Method` and `extend Strict::Interface` forms are not 
 
 `Strict::Value` and `Strict::Object` add an `attributes` declaration block. Each declaration accepts an attribute name, an optional validator, `coerce:`, and one of `default:`, `default_value:`, or `default_generator:`.
 
-Attribute names must be strings or symbols in the supported identifier shape: a lowercase ASCII letter or underscore, followed by ASCII letters, digits, or underscores, with one optional trailing `?` or `!`. Use `strict_attribute` when a name is a Ruby reserved word or already resolves to a method inside the declaration block, for example `strict_attribute :if` or `strict_attribute :format`. Empty names, operators, setters, and other method-name forms are rejected. Each distinct supported name has independent backing storage, including names that differ only by a trailing `?` or `!`. A mutable object's punctuation writer can be called with `public_send`, for example `object.public_send(:"active?=", false)`.
+Attribute names must be strings or symbols in the supported identifier shape: a lowercase ASCII letter or underscore, followed by ASCII letters, digits, or underscores, with one optional trailing `?` or `!`. Use `strict_attribute` when a name is a Ruby reserved word or already resolves to a method inside the declaration block, for example `strict_attribute :if` or `strict_attribute :format`. Empty names, operators, setters, and other method-name forms are rejected. Generated accessors use the conventional backing instance variable formed by removing a trailing `?` or `!` from the attribute name, so `active?` uses `@active`. Class behavior can read this declared state directly; writing it directly bypasses validation and is unsupported. A mutable object's punctuation writer can be called with `public_send`, for example `object.public_send(:"active?=", false)`.
 
 Both capabilities provide:
 
@@ -41,7 +41,7 @@ Both capabilities provide:
 - `==` and `eql?`, based on exact class and attribute values;
 - `hash`, consistent with `eql?`.
 
-A class can execute at most one `attributes` block, and an empty block counts as that one block. A subclass inherits its parent's attributes and can execute one additive `attributes` block without changing the parent. An attribute cannot duplicate another attribute in the same block or an inherited attribute.
+A class can execute at most one `attributes` block, and an empty block counts as that one block. A subclass inherits its parent's attributes and can execute one additive `attributes` block without changing the parent. An attribute cannot duplicate another attribute in the same block or an inherited attribute. Attribute names also cannot map to the same backing instance variable, such as `active`, `active?`, and `active!`, including across inherited declarations.
 
 Before it installs generated methods, Strict rejects an attribute whose reader would collide with a public, protected, or private instance method defined directly on the declaring class. It also rejects methods reserved by `BasicObject`, the active Strict capability, or Strict's generated implementation, including `as_json`, `class`, `to_h`, `inspect`, `hash`, `eql?`, `initialize`, `pretty_print`, and `public_send`. `Strict::Object` applies the same checks to its generated writer.
 
@@ -128,7 +128,7 @@ PaymentResult::Authorized.new(
 # => { status: "payment.authorized", request_id: "request_123", authorization_id: "auth_123", amount_in_cents: 1_000 }
 ```
 
-Variants therefore use the documented `Strict::Value` behavior for initialization, validation, coercion, defaults, copying, equality, hashing, conversion, inspection, pattern matching, and declaration errors. A variant attribute cannot duplicate the discriminator or a shared union attribute, and generated readers cannot collide with methods defined in the variant block. The union base cannot be instantiated directly.
+Variants therefore use the documented `Strict::Value` behavior for initialization, validation, coercion, defaults, copying, equality, hashing, conversion, inspection, pattern matching, and declaration errors. A variant attribute cannot duplicate or share a backing instance variable with the discriminator or a shared union attribute, and generated readers cannot collide with methods defined in the variant block. The union base cannot be instantiated directly.
 
 `PaymentResult === value` is true only when `value` has the exact class of a registered variant. Generated variant classes retain normal Ruby class matching, including matching instances of their subclasses. Union and variant inheritance are outside the compatibility boundary.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@
 - Forward validated interface calls directly to implementations and compile interface-conformance expectations once per interface definition.
 - Check interface implementation signatures by substitutability: require every exposed keyword and reject only additional parameters that can constrain a valid interface call.
 - Reduce value and object hot-path allocations during initialization, `to_h`, equality, and hashing.
-- Share declaration invariants between attributes and parameters, with isolated backing storage for every distinct attribute name.
+- Share declaration invariants between attributes and parameters, preserve conventional attribute backing instance variables, and reject attribute names that map to the same storage.
 - Automatically use a validator's coercer for attributes and parameters unless the declaration overrides or disables coercion.
 - Propagate default coercion through `ArrayOf` elements and `HashOf` keys and values.
 - Keep Strict configuration overrides in isolated internal execution-context storage to avoid collisions with application keys.

--- a/lib/strict/attribute.rb
+++ b/lib/strict/attribute.rb
@@ -3,6 +3,10 @@
 module Strict
   class Attribute < Declaration
     class << self
+      def instance_variable_for(name)
+        "@#{name.to_s.delete_suffix("?").delete_suffix("!")}"
+      end
+
       private
 
       def coercer_supported?(coercer)
@@ -14,7 +18,7 @@ module Strict
 
     def initialize(name:, validator:, default_generator:, coercer:)
       super
-      @instance_variable = :"@__strict_attribute_#{self.name.to_s.b.unpack1('H*')}"
+      @instance_variable = self.class.instance_variable_for(self.name)
     end
 
     def coerce(value, for_class:)

--- a/lib/strict/attribute.rb
+++ b/lib/strict/attribute.rb
@@ -4,7 +4,7 @@ module Strict
   class Attribute < Declaration
     class << self
       def instance_variable_for(name)
-        "@#{name.to_s.delete_suffix("?").delete_suffix("!")}"
+        "@#{name.to_s.delete_suffix('?').delete_suffix('!')}"
       end
 
       private

--- a/lib/strict/attributes/configuration.rb
+++ b/lib/strict/attributes/configuration.rb
@@ -30,6 +30,7 @@ module Strict
       attr_reader :attributes
 
       def initialize(attributes:)
+        validate_instance_variables!(attributes)
         @attributes = attributes
         @attributes_index = attributes.to_h { |a| [a.name, a] }
       end
@@ -41,6 +42,20 @@ module Strict
       private
 
       attr_reader :attributes_index
+
+      def validate_instance_variables!(attributes)
+        attributes_by_instance_variable = {}
+        attributes.each do |attribute|
+          conflicting_attribute = attributes_by_instance_variable[attribute.instance_variable]
+          if conflicting_attribute
+            raise ArgumentError,
+                  "Attribute #{attribute.name.inspect} conflicts with #{conflicting_attribute.name.inspect} " \
+                  "because both use #{attribute.instance_variable}"
+          end
+
+          attributes_by_instance_variable[attribute.instance_variable] = attribute
+        end
+      end
     end
   end
 end

--- a/lib/strict/union.rb
+++ b/lib/strict/union.rb
@@ -125,7 +125,19 @@ module Strict
       # rubocop:enable Metrics/MethodLength
 
       def strict_union_validate_attributes!(attributes, discriminator)
-        return unless discriminator && attributes&.any? { |attribute| attribute.name.eql?(discriminator) }
+        return unless discriminator && attributes
+
+        discriminator_instance_variable = Attribute.instance_variable_for(discriminator)
+        conflicting_attribute = attributes.find do |attribute|
+          attribute.instance_variable.eql?(discriminator_instance_variable)
+        end
+        return unless conflicting_attribute
+
+        unless conflicting_attribute.name.eql?(discriminator)
+          raise ArgumentError,
+                "union attributes cannot conflict with discriminator #{discriminator.inspect}: " \
+                "#{conflicting_attribute.name.inspect} uses #{discriminator_instance_variable}"
+        end
 
         raise ArgumentError, "union attributes cannot redeclare discriminator #{discriminator.inspect}"
       end

--- a/lib/strict/union.rb
+++ b/lib/strict/union.rb
@@ -127,19 +127,17 @@ module Strict
       def strict_union_validate_attributes!(attributes, discriminator)
         return unless discriminator && attributes
 
-        discriminator_instance_variable = Attribute.instance_variable_for(discriminator)
-        conflicting_attribute = attributes.find do |attribute|
-          attribute.instance_variable.eql?(discriminator_instance_variable)
-        end
+        storage = Attribute.instance_variable_for(discriminator)
+        conflicting_attribute = attributes.find { |attribute| attribute.instance_variable.eql?(storage) }
         return unless conflicting_attribute
 
-        unless conflicting_attribute.name.eql?(discriminator)
-          raise ArgumentError,
-                "union attributes cannot conflict with discriminator #{discriminator.inspect}: " \
-                "#{conflicting_attribute.name.inspect} uses #{discriminator_instance_variable}"
+        if conflicting_attribute.name.eql?(discriminator)
+          raise ArgumentError, "union attributes cannot redeclare discriminator #{discriminator.inspect}"
         end
 
-        raise ArgumentError, "union attributes cannot redeclare discriminator #{discriminator.inspect}"
+        raise ArgumentError,
+              "union attributes cannot conflict with discriminator #{discriminator.inspect}: " \
+              "#{conflicting_attribute.name.inspect} uses #{storage}"
       end
 
       def strict_union_discriminator_coercer(discriminator, tag)

--- a/spec/strict/attribute_spec.rb
+++ b/spec/strict/attribute_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Strict::Attribute do
       expect(attribute.validator).to eq(Strict::Validators::Anything.instance)
       expect(attribute.default_generator).to eq(Strict::Attribute::NOT_PROVIDED)
       expect(attribute.coercer).to be_falsey
-      expect(attribute.instance_variable).to eq(:@__strict_attribute_617474725f6e616d65)
+      expect(attribute.instance_variable).to eq("@attr_name")
       expect(attribute).not_to be_optional
     end
 
@@ -23,8 +23,13 @@ RSpec.describe Strict::Attribute do
       expect(attribute.default_generator).not_to eq(Strict::Attribute::NOT_PROVIDED)
       expect(attribute.default_generator.call).to eq(1)
       expect(attribute.coercer).to be_truthy
-      expect(attribute.instance_variable).to eq(:@__strict_attribute_617474725f6e616d65)
+      expect(attribute.instance_variable).to eq("@attr_name")
       expect(attribute).to be_optional
+    end
+
+    it "removes trailing predicate and bang punctuation from the instance variable" do
+      expect(described_class.make(:active?).instance_variable).to eq("@active")
+      expect(described_class.make(:save!).instance_variable).to eq("@save")
     end
 
     it "accepts a validator" do

--- a/spec/strict/attributes/configuration_spec.rb
+++ b/spec/strict/attributes/configuration_spec.rb
@@ -36,13 +36,12 @@ RSpec.describe Strict::Attributes::Configuration do
 
   it "rejects attributes that use the same backing instance variable" do
     attributes = [
-      Strict::Attribute.make(:value),
       Strict::Attribute.make(:value?),
       Strict::Attribute.make(:value!)
     ]
 
     expect do
       described_class.new(attributes: attributes)
-    end.to raise_error(ArgumentError, /Attribute :value\? conflicts with :value/)
+    end.to raise_error(ArgumentError, /Attribute :value! conflicts with :value\?/)
   end
 end

--- a/spec/strict/attributes/configuration_spec.rb
+++ b/spec/strict/attributes/configuration_spec.rb
@@ -33,4 +33,16 @@ RSpec.describe Strict::Attributes::Configuration do
       end.to raise_error(Strict::Attributes::Configuration::UnknownAttributeError)
     end
   end
+
+  it "rejects attributes that use the same backing instance variable" do
+    attributes = [
+      Strict::Attribute.make(:value),
+      Strict::Attribute.make(:value?),
+      Strict::Attribute.make(:value!)
+    ]
+
+    expect do
+      described_class.new(attributes: attributes)
+    end.to raise_error(ArgumentError, /Attribute :value\? conflicts with :value/)
+  end
 end

--- a/spec/strict/strict_public_api_spec.rb
+++ b/spec/strict/strict_public_api_spec.rb
@@ -108,22 +108,34 @@ RSpec.describe Strict do
       expect(value_with_overridden_reader.hash).to eq(equal_value.hash)
     end
 
-    it "stores attribute names with the same stem independently" do
+    it "makes conventional backing instance variables available to custom behavior" do
       value_class = Class.new do
         include Strict::Value
 
         attributes do
-          strict_attribute :value, String
-          strict_attribute :value?, Integer
-          strict_attribute :value!, Symbol
+          name String
+          active? Boolean()
         end
-      end
-      value = value_class.new(value: "plain", value?: 1, value!: :dangerous)
 
-      expect(value.value).to eq("plain")
-      expect(value.value?).to eq(1)
-      expect(value.value!).to eq(:dangerous)
-      expect(value.to_h).to eq(value: "plain", value?: 1, value!: :dangerous)
+        def state = [@name, @active]
+      end
+      value = value_class.new(name: "Ada", active?: true)
+
+      expect(value.state).to eq(["Ada", true])
+      expect(value.instance_variables).to contain_exactly(:@name, :@active)
+    end
+
+    it "rejects attribute names that use the same backing instance variable" do
+      expect do
+        Class.new do
+          include Strict::Value
+
+          attributes do
+            strict_attribute :value, String
+            strict_attribute :value?, Integer
+          end
+        end
+      end.to raise_error(ArgumentError, /Attribute :value\? conflicts with :value/)
     end
 
     it "rejects invalid attribute declarations before installing methods" do
@@ -195,28 +207,24 @@ RSpec.describe Strict do
       end.to raise_error(Strict::AssignmentError) { |error| expect(error.value).to eq("no") }
     end
 
-    it "stores attribute names with the same stem independently" do
+    it "updates conventional backing instance variables through validated writers" do
       object_class = Class.new do
         include Strict::Object
 
         attributes do
-          strict_attribute :value, String
-          strict_attribute :value?, Integer
-          strict_attribute :value!, Symbol
+          name String
+          active? Boolean()
         end
+
+        def state = [@name, @active]
       end
-      object = object_class.new(value: "plain", value?: 1, value!: :dangerous)
+      object = object_class.new(name: "Ada", active?: true)
 
-      expect(object.to_h).to eq(value: "plain", value?: 1, value!: :dangerous)
+      object.name = "Grace"
+      object.public_send(:"active?=", false)
 
-      object.value = "changed"
-      object.public_send(:"value?=", 2)
-      object.public_send(:"value!=", :changed)
-
-      expect(object.value).to eq("changed")
-      expect(object.value?).to eq(2)
-      expect(object.value!).to eq(:changed)
-      expect(object.to_h).to eq(value: "changed", value?: 2, value!: :changed)
+      expect(object.state).to eq(["Grace", false])
+      expect(object.instance_variables).to contain_exactly(:@name, :@active)
     end
 
     it "inherits writers and resolves class coercers on the receiving class" do

--- a/spec/strict/strict_public_api_spec.rb
+++ b/spec/strict/strict_public_api_spec.rb
@@ -176,6 +176,10 @@ RSpec.describe Strict do
       end.to raise_error(ArgumentError)
 
       expect do
+        Class.new(parent_class) { attributes { name? Boolean() } }
+      end.to raise_error(ArgumentError, /Attribute :name\? conflicts with :name/)
+
+      expect do
         parent_class.attributes { employee_id String }
       end.to raise_error(ArgumentError)
     end

--- a/spec/strict/union_spec.rb
+++ b/spec/strict/union_spec.rb
@@ -363,6 +363,29 @@ RSpec.describe Strict::Union do
     end.to raise_error(ArgumentError)
   end
 
+  it "rejects attributes that share backing storage across a composed variant" do
+    expect do
+      Class.new do
+        include Strict::Union
+
+        discriminator :kind
+        attributes { request_id String }
+        variant :invalid do
+          attributes { request_id? Boolean() }
+        end
+      end
+    end.to raise_error(ArgumentError, /Attribute :request_id\? conflicts with :request_id/)
+
+    expect do
+      Class.new do
+        include Strict::Union
+
+        attributes { kind? Boolean() }
+        discriminator :kind
+      end
+    end.to raise_error(ArgumentError, /union attributes cannot conflict with discriminator :kind/)
+  end
+
   it "rejects variant attributes that collide with variant methods" do
     expect do
       Class.new do


### PR DESCRIPTION
## Summary

- restore conventional backing instance variables for declared attributes
- reject attribute names that map to the same storage across inheritance and union composition
- document backing ivar compatibility and direct-write limitations

## Verification

- `mise exec -- bundle exec rake`
