### PR TITLE
Prepare Strict 2.0.0 for release

### DIFF
--- a/API.md
+++ b/API.md
@@ -1,6 +1,6 @@
 # Supported API
 
-This document defines the compatibility boundary for Strict's next major release. Code inside this boundary is public API. Other reachable Ruby constants, methods, generated modules, and reflection details are implementation details unless this document identifies them as public.
+This document defines the compatibility boundary for Strict 2.0. Code inside this boundary is public API. Other reachable Ruby constants, methods, generated modules, and reflection details are implementation details unless this document identifies them as public.
 
 ## Capabilities
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 ### Changed
 
 - Require Ruby 3.3 or newer and test against all maintained Ruby releases.
-- Update runtime and development dependencies to their latest release lines.
+- Update development dependencies to their latest release lines while retaining Zeitwerk 2.x compatibility from 2.6 onward.
 - Compile signed-method invocation metadata once, reuse unchanged call arguments, and consolidate generated wrappers by owner.
 - Preserve validated explicit keywords when keyrest processing changes a signed call.
 - Forward validated interface calls directly to implementations and compile interface-conformance expectations once per interface definition.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 ## [Unreleased]
 
+## [2.0.0] - 2026-08-21
+
 ### Added
 
-- Define and characterize the supported next-major API in `API.md`, provide RBS signatures for that boundary, validate them in the default checks, and add repeatable timing and allocation benchmark tooling.
+- Define and characterize the supported 2.0 API in `API.md`, provide RBS signatures for that boundary, validate them in the default checks, and add repeatable timing and allocation benchmark tooling.
 - Add closed discriminated unions whose generated variants use `Strict::Value` for attributes and value behavior.
 - Add inherited value and object attribute declarations and shared union attributes.
 - Add structured validation violations with paths, codes, rejected values, and validators for assignment, initialization, signed method calls, and returns, plus an optional detailed-validator protocol for custom nested failures.
@@ -11,7 +13,7 @@
 
 ### Breaking changes
 
-- Standardize all four capabilities on `include`: `Strict::Value`, `Strict::Object`, `Strict::Method`, and `Strict::Interface`. The legacy `extend Strict::Method` and `extend Strict::Interface` forms are outside the supported next-major API.
+- Standardize all four capabilities on `include`: `Strict::Value`, `Strict::Object`, `Strict::Method`, and `Strict::Interface`. The legacy `extend Strict::Method` and `extend Strict::Interface` forms are outside the supported 2.0 API.
 - Make signed method returns validate-only. `returns` rejects coercion options, validates the original result, and preserves its identity for the caller.
 - Reject malformed or same-block duplicate attribute declarations, repeated attribute blocks, duplicate or repeated signatures, and same-class or Strict/core-reserved generated attribute method collisions with `ArgumentError` instead of silently replacing declarations or installing pathological methods.
 
@@ -100,7 +102,8 @@ The equal-weight geometric mean of the eight after/before timing ratios is 0.57,
 
 - Start initial development.
 
-[Unreleased]: https://github.com/kylekthompson/strict/compare/v1.5.0...HEAD
+[Unreleased]: https://github.com/kylekthompson/strict/compare/v2.0.0...HEAD
+[2.0.0]: https://github.com/kylekthompson/strict/compare/v1.5.0...v2.0.0
 [1.5.0]: https://github.com/kylekthompson/strict/compare/v1.4.0...v1.5.0
 [1.4.0]: https://github.com/kylekthompson/strict/compare/v1.3.1...v1.4.0
 [1.3.1]: https://github.com/kylekthompson/strict/compare/v1.3.0...v1.3.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    strict (1.5.0)
+    strict (2.0.0)
       zeitwerk (~> 2.8)
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     strict (2.0.0)
-      zeitwerk (~> 2.8)
+      zeitwerk (~> 2.6)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ $ gem install strict
 
 ## Usage
 
-See [Supported API](API.md) for the next major release's compatibility boundary.
+See [Supported API](API.md) for the 2.0 compatibility boundary.
 
 ### `Strict::Value`
 

--- a/lib/strict/version.rb
+++ b/lib/strict/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Strict
-  VERSION = "1.5.0"
+  VERSION = "2.0.0"
 end

--- a/strict.gemspec
+++ b/strict.gemspec
@@ -29,5 +29,5 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "zeitwerk", "~> 2.8"
+  spec.add_dependency "zeitwerk", "~> 2.6"
 end


### PR DESCRIPTION
## Summary

- prepare Strict 2.0.0 release metadata and documentation
- finalize the 2.0.0 changelog and compatibility boundary
- retain compatibility with Zeitwerk 2.x from version 2.6 onward

## Verification

- `bundle exec rake`
- 329 specs with Zeitwerk 2.6.0
- build and load `strict-2.0.0.gem` with Zeitwerk 2.6.0 in an isolated gem installation
