### PR TITLE
Add union variant convenience methods

### DIFF
--- a/API.md
+++ b/API.md
@@ -116,10 +116,12 @@ There is no default discriminator. A union can declare zero or one `attributes` 
 
 A variant name must be a lower snake-case string or symbol, and Strict generates its PascalCase nested subclass. By default, the discriminator tag is the name's corresponding symbol. The optional `tag:` can assign a different string or symbol. For example, `variant :requires_action, tag: "action-required"` generates `PaymentResult::RequiresAction < PaymentResult` with the tag `"action-required"`.
 
+Each variant name also generates a class-level convenience constructor and an instance interrogation method. `PaymentResult.authorized(...)` calls `PaymentResult::Authorized.new(...)`. Every union member responds to `authorized?`, which is true for authorized members and false for other variants. These methods use the variant name even when the discriminator tag differs.
+
 The variant block configures the generated subclass. It can include modules, define methods, and contain zero or one `attributes` block. Strict combines the discriminator, shared union attributes, and variant attributes in that order. The discriminator is an implicit first attribute with a fixed default value:
 
 ```ruby
-PaymentResult::Authorized.new(
+PaymentResult.authorized(
   request_id: "request_123",
   authorization_id: "auth_123",
   amount_in_cents: 1_000
@@ -127,7 +129,7 @@ PaymentResult::Authorized.new(
 # => { status: "payment.authorized", request_id: "request_123", authorization_id: "auth_123", amount_in_cents: 1_000 }
 ```
 
-Variants therefore use the documented `Strict::Value` behavior for initialization, validation, coercion, defaults, copying, equality, hashing, conversion, inspection, pattern matching, and declaration errors. A variant attribute cannot duplicate or share a backing instance variable with the discriminator or a shared union attribute, and generated readers cannot collide with methods defined in the variant block. The union base cannot be instantiated directly.
+Variants therefore use the documented `Strict::Value` behavior for initialization, validation, coercion, defaults, copying, equality, hashing, conversion, inspection, pattern matching, and declaration errors. A variant attribute cannot duplicate or share a backing instance variable with the discriminator or a shared union attribute, and generated readers cannot collide with methods defined in the variant block. Generated convenience constructors and interrogation methods cannot collide with existing class or instance methods or with variant behavior. The union base cannot be instantiated directly.
 
 `PaymentResult === value` is true only when `value` has the exact class of a registered variant. Generated variant classes retain normal Ruby class matching, including matching instances of their subclasses. Union and variant inheritance are outside the compatibility boundary.
 
@@ -147,7 +149,7 @@ payment_result PaymentResult
 strict_payment_result PaymentResult, coerce: false
 ```
 
-Declaring a discriminator more than once, declaring equivalent duplicate string or symbol tags, using an invalid variant name or tag, replacing an existing generated constant, declaring multiple union or variant attribute blocks, declaring union attributes after a variant, or redeclaring the discriminator raises `ArgumentError`. Declaration return values, generated-class reflection details, and the exact text of declaration and coercion errors are outside the compatibility boundary.
+Declaring a discriminator more than once, declaring equivalent duplicate string or symbol tags, using an invalid or conflicting variant name or tag, replacing an existing generated constant, declaring multiple union or variant attribute blocks, declaring union attributes after a variant, or redeclaring the discriminator raises `ArgumentError`. Declaration return values, generated-class reflection details, and the exact text of declaration and coercion errors are outside the compatibility boundary.
 
 ### Signed methods
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+## [2.1.0] - 2026-08-21
+
 ### Added
 
 - Add class-level convenience constructors and instance interrogation methods for every `Strict::Union` variant.
@@ -106,7 +108,8 @@ The equal-weight geometric mean of the eight after/before timing ratios is 0.57,
 
 - Start initial development.
 
-[Unreleased]: https://github.com/kylekthompson/strict/compare/v2.0.0...HEAD
+[Unreleased]: https://github.com/kylekthompson/strict/compare/v2.1.0...HEAD
+[2.1.0]: https://github.com/kylekthompson/strict/compare/v2.0.0...v2.1.0
 [2.0.0]: https://github.com/kylekthompson/strict/compare/v1.5.0...v2.0.0
 [1.5.0]: https://github.com/kylekthompson/strict/compare/v1.4.0...v1.5.0
 [1.4.0]: https://github.com/kylekthompson/strict/compare/v1.3.1...v1.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+### Added
+
+- Add class-level convenience constructors and instance interrogation methods for every `Strict::Union` variant.
+
 ## [2.0.0] - 2026-08-20
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    strict (2.0.0)
+    strict (2.1.0)
       zeitwerk (~> 2.6)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -103,13 +103,19 @@ class PaymentResult
   end
 end
 
-authorized = PaymentResult::Authorized.new(
+authorized = PaymentResult.authorized(
   request_id: "request_123",
   authorization_id: "auth_123",
   amount_in_cents: 1_000
 )
 authorized.to_h
 # => { status: "payment.authorized", request_id: "request_123", authorization_id: "auth_123", amount_in_cents: 1_000 }
+
+authorized.authorized?
+# => true
+
+authorized.declined?
+# => false
 
 authorized.successful?
 # => true

--- a/lib/strict/union.rb
+++ b/lib/strict/union.rb
@@ -43,6 +43,7 @@ module Strict
         tag_key = strict_union_tag_key(tag)
         constant_name = strict_union_validate_variant!(name, tag, tag_key)
         variant_class = strict_union_build_variant(discriminator, name, tag, definition)
+        strict_union_validate_interrogation_method!(name, variant_class)
         strict_union_register_variant(name, tag, tag_key, constant_name, variant_class)
       end
 
@@ -66,15 +67,48 @@ module Strict
         raise ArgumentError, "tag #{tag.inspect} already declared for #{self}" if @strict_union_variants.key?(tag_key)
         raise ArgumentError, "constant #{constant_name} is already defined for #{self}" if
           const_defined?(constant_name, false)
+        raise ArgumentError, "variant convenience method #{name.inspect} already exists for #{self}" if
+          strict_union_method_defined?(singleton_class, name)
 
         constant_name
+      end
+
+      def strict_union_validate_interrogation_method!(name, variant_class)
+        method_name = strict_union_interrogation_method(name)
+        owners = [self, *@strict_union_variant_names.values, variant_class]
+        conflicting_owner = owners.find { |owner| strict_union_method_defined?(owner, method_name) }
+        raise ArgumentError, "interrogation method #{method_name.inspect} already exists for #{conflicting_owner}" if
+          conflicting_owner
+
+        strict_union_validate_existing_interrogation_methods!(variant_class)
+      end
+
+      def strict_union_validate_existing_interrogation_methods!(variant_class)
+        @strict_union_variant_names.each_key do |variant_name|
+          existing_method = strict_union_interrogation_method(variant_name)
+          next if variant_class.instance_method(existing_method).owner.equal?(self)
+
+          raise ArgumentError, "interrogation method #{existing_method.inspect} already exists for #{variant_class}"
+        end
       end
 
       def strict_union_register_variant(name, tag, tag_key, constant_name, variant_class)
         const_set(constant_name, variant_class)
         @strict_union_variant_names[name] = variant_class
         @strict_union_variants[tag_key] = Variant.new(tag:, variant_class:)
+        define_singleton_method(name) { |**attributes| variant_class.new(**attributes) }
+        define_method(strict_union_interrogation_method(name)) { variant_class === self }
         variant_class
+      end
+
+      def strict_union_interrogation_method(name)
+        :"#{name}?"
+      end
+
+      def strict_union_method_defined?(owner, name)
+        owner.public_method_defined?(name) ||
+          owner.protected_method_defined?(name) ||
+          owner.private_method_defined?(name)
       end
 
       def strict_union_discriminator!

--- a/lib/strict/version.rb
+++ b/lib/strict/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Strict
-  VERSION = "2.0.0"
+  VERSION = "2.1.0"
 end

--- a/spec/strict/union_spec.rb
+++ b/spec/strict/union_spec.rb
@@ -40,6 +40,26 @@ RSpec.describe Strict::Union do
     expect(union_class === declined).to be(true)
   end
 
+  it "generates an interrogation method for each variant" do
+    authorized = union_class::Authorized.new(authorization_id: "auth_123", amount_in_cents: 1_000)
+    declined = union_class::Declined.new(reason: "insufficient_funds")
+
+    expect(authorized.authorized?).to be(true)
+    expect(authorized.declined?).to be(false)
+    expect(declined.authorized?).to be(false)
+    expect(declined.declined?).to be(true)
+  end
+
+  it "generates a class-level constructor for each variant" do
+    authorized = union_class.authorized(authorization_id: "auth_123", amount_in_cents: 1_000)
+    declined = union_class.declined(reason: "insufficient_funds")
+
+    expect(authorized).to eq(
+      union_class::Authorized.new(authorization_id: "auth_123", amount_in_cents: 1_000)
+    )
+    expect(declined).to eq(union_class::Declined.new(reason: "insufficient_funds"))
+  end
+
   it "shares union attributes across variants" do
     result_class = Class.new do
       include Strict::Union
@@ -116,10 +136,13 @@ RSpec.describe Strict::Union do
     authorized = result_class::Authorized.new(status: :"some-string", authorization_id: "auth_123")
     string_input = result_class.coercer.call(status: "some-string", authorization_id: "auth_123")
     symbol_input = result_class.coercer.call(status: :"some-string", authorization_id: "auth_123")
+    convenience = result_class.authorized(authorization_id: "auth_123")
 
     expect(authorized.to_h).to eq(status: "some-string", authorization_id: "auth_123")
     expect(string_input).to eq(authorized)
     expect(symbol_input).to eq(authorized)
+    expect(convenience).to eq(authorized)
+    expect(convenience.authorized?).to be(true)
   end
 
   it "automatically coerces values when used as an attribute validator" do
@@ -399,5 +422,55 @@ RSpec.describe Strict::Union do
         end
       end
     end.to raise_error(ArgumentError)
+  end
+
+  it "rejects variant behavior that collides with its interrogation method" do
+    expect do
+      Class.new do
+        include Strict::Union
+
+        discriminator :kind
+        variant :complete do
+          def complete? = false
+        end
+      end
+    end.to raise_error(ArgumentError, /interrogation method :complete\? already exists/)
+  end
+
+  it "rejects behavior that collides with another variant's interrogation method" do
+    future_collision = Class.new do
+      include Strict::Union
+
+      discriminator :kind
+      variant :first do
+        def second? = false
+      end
+    end
+    existing_collision = Class.new do
+      include Strict::Union
+
+      discriminator :kind
+      variant :first
+    end
+
+    expect do
+      future_collision.variant :second
+    end.to raise_error(ArgumentError, /interrogation method :second\? already exists/)
+    expect do
+      existing_collision.variant :second do
+        def first? = false
+      end
+    end.to raise_error(ArgumentError, /interrogation method :first\? already exists/)
+  end
+
+  it "rejects variant names that collide with class-level convenience methods" do
+    expect do
+      Class.new do
+        include Strict::Union
+
+        discriminator :kind
+        variant :name
+      end
+    end.to raise_error(ArgumentError, /variant convenience method :name already exists/)
   end
 end


### PR DESCRIPTION
## Summary

- generate class-level constructors for each `Strict::Union` variant
- generate instance interrogation methods and reject method-name collisions
- document the convenience API and prepare version 2.1.0

## Testing

- `bundle exec rake`
- `bundle exec gem build strict.gemspec --output /tmp/strict-2.1.0.gem`
